### PR TITLE
Add binary data type hints + lint the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # pymbus
 
-Another Meter-Bus codec/parser written in Python.
+Another Meter-Bus codec written in Python.
+
+## Installation
+
+From source:
+
+```shell
+pip install https://github.com/stankudrow/pymbus.git
+```
+
+Please refer to the pip documentation on the [VCS support](https://pip.pypa.io/en/stable/topics/vcs-support/).
 
 ## References
 
 Many thanks to Mikael Ganehag Brorsson for [pyMeterBus](https://github.com/ganehag/pyMeterBus) project and its contributors.
-The same gratiyude to the community of [libmbus](https://github.com/rscada/libmbus) project.
+The same gratitude to the community of the [libmbus](https://github.com/rscada/libmbus) project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ omit = ["tests"]
 source = ["src"]
 
 [tool.coverage.report]
-fail_under = 83
+fail_under = 90
 precision = 0
 skip_covered = true
 skip_empty = true
@@ -122,6 +122,7 @@ select = [
     "DTZ",  # flake8-datetimez
     "EM",  # flake8-errmsg
     "ERA",  # eradicate
+    "F",  # Pyflakes
     "FBT",  # flake8-boolean-trap
     "I",  # isort
     "ICN",  # flake8-import-conventions
@@ -132,7 +133,11 @@ select = [
     "Q",  # flake8-quotes
     "RSE",  # flake8-raise
     "RET",  # flake8-return
+    "S",  # flake8-bandit
+    "SLF",  # flake8-self
+    "SIM",  # flake8-simplify
     "T",  # flake8-print-linter
+    "T10",  # flake8-debugger
     "T20",  # flake8-print
     "TC",  # flake8-type-checking
     "TID",  # flake8-tidy-imports
@@ -149,5 +154,6 @@ fixable = ["I", "ICN", "ISC"]
 "tests/*.py" = [
     "ANN201",  # https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/
     "FBT001",  # https://docs.astral.sh/ruff/rules/boolean-type-hint-positional-argument/
-    "PT011"  # https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
+    "PT011",  # https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
+    "S",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymbus"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python Meter-Bus codec."
 authors = [
     { name = "Stanley Kudrow", email = "stankudrow@reply.no" }
@@ -12,10 +12,22 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
-    "Programming Language :: Python :: 3 :: Only",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: MIT License",
+    "License :: Public Domain",
+    "Natural Language :: English",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython"
 ]
-keywords = ["meter-bus", "m-bus"]
+keywords = ["meter-bus", "m-bus", "meters"]
 dependencies = []
 
 [project.optional-dependencies]

--- a/src/pymbus/codes/value_info.py
+++ b/src/pymbus/codes/value_info.py
@@ -11,7 +11,7 @@ class ValueInformationFieldCode:
     UNIT: Any = None
 
     def __init__(self, vif: VIF) -> None:
-        self.check_coding(vif)
+        self.validate_vif(vif)
         self._vif = vif
         self._range = None
 
@@ -19,7 +19,7 @@ class ValueInformationFieldCode:
     def multiplier(self) -> None | int | float:
         return self._range
 
-    def check_coding(self, vif: VIF) -> None:
+    def validate_vif(self, vif: VIF) -> None:
         byte = vif.byte
         cmask = self.CMASK
         if emask := self.EMASK:
@@ -190,6 +190,6 @@ def get_vif_code(vif: VIF) -> None | ValueInformationFieldCode:
     for code_type in VIF_CODE_TYPES:
         try:
             return code_type(vif)
-        except Exception:  # noqa: BLE001
+        except MBusError:
             pass
     return None

--- a/src/pymbus/mbtypes.py
+++ b/src/pymbus/mbtypes.py
@@ -42,10 +42,11 @@ Type G, or Compound CP16: Date -> 2 bytes.
 
 import struct
 from collections.abc import Iterable
+from contextlib import suppress
 from datetime import date, datetime, time, timezone, tzinfo
 
-from pymbus.constants import BIG_ENDIAN, BYTE, NIBBLE
-from pymbus.exceptions import MBusError, MBusLengthError, MBusValidationError
+from pymbus.constants import BIG_ENDIAN, NIBBLE
+from pymbus.exceptions import MBusError, MBusLengthError
 
 BytesType = bytes | bytearray | Iterable[int]
 
@@ -615,10 +616,8 @@ def parse_datetime(ibytes: BytesType) -> datetime:
     except StopIteration as e:
         raise MBusLengthError(str(ibytes)) from e
 
-    try:
+    with suppress(StopIteration):
         lst += [next(it)]
-    except StopIteration:
-        pass
 
     fields = bytes(lst)
 

--- a/src/pymbus/telegrams/base.py
+++ b/src/pymbus/telegrams/base.py
@@ -64,10 +64,11 @@ class TelegramField:
 
 
 TelegramByteType = int | TelegramField
+TelegramBytesType = bytes | bytearray | Iterable[TelegramByteType]
 
 
 def _convert_to_telegram_fields(
-    ibytes: Iterable[TelegramByteType],
+    ibytes: TelegramBytesType,
 ) -> list[TelegramField]:
     return [
         ibyte if isinstance(ibyte, TelegramField) else TelegramField(ibyte)
@@ -100,9 +101,7 @@ class TelegramContainer:
         except ValueError as e:
             raise MBusValidationError(str(e)) from e
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         self._fields = _convert_to_telegram_fields(ibytes or [])
 
     def __eq__(self, other: object) -> bool:
@@ -127,9 +126,6 @@ class TelegramContainer:
     def __repr__(self) -> str:
         cls_name = type(self).__name__
         return f"{cls_name}(ibytes={self._fields})"
-
-    def __str__(self) -> str:
-        return str(list(self))
 
     def as_bytes(self) -> bytes:
         return bytes(field.byte for field in self._fields)

--- a/src/pymbus/telegrams/blocks.py
+++ b/src/pymbus/telegrams/blocks.py
@@ -1,8 +1,8 @@
-from collections.abc import Iterable
+"""M-Bus Telegram Blocks module."""
 
 from pymbus.exceptions import MBusLengthError
 from pymbus.telegrams.base import (
-    TelegramByteType,
+    TelegramBytesType,
     TelegramContainer,
     TelegramField,
 )
@@ -37,9 +37,7 @@ class DataInformationBlock(TelegramBlock):
 
     MAX_DIFE_FRAMES = 10
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         container = list(TelegramContainer(ibytes=ibytes))
 
         blocks = self._parse_blocks(container)
@@ -109,9 +107,7 @@ class ValueInformationBlock(TelegramBlock):
 
     MAX_VIFE_FRAMES = 10
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         container = list(TelegramContainer(ibytes=ibytes))
 
         blocks = self._parse_blocks(container)

--- a/src/pymbus/telegrams/fields.py
+++ b/src/pymbus/telegrams/fields.py
@@ -1,4 +1,4 @@
-"""The (Telegram) Fields module."""
+"""M-Bus Telegram Fields module."""
 
 from enum import IntEnum
 

--- a/src/pymbus/telegrams/frames.py
+++ b/src/pymbus/telegrams/frames.py
@@ -1,4 +1,4 @@
-"""Telegram frames of the M-Bus protocol.
+"""M-Bus Telegram Frames module.
 
 The fields:
 
@@ -9,11 +9,9 @@ The fields:
 
 """
 
-from collections.abc import Iterable
-
 from pymbus.exceptions import MBusLengthError, MBusValidationError
 from pymbus.telegrams.base import (
-    TelegramByteType,
+    TelegramBytesType,
     TelegramContainer,
     TelegramField,
 )
@@ -64,9 +62,7 @@ class SingleFrame(TelegramFrame):
 
         return SingleFrame([byte])
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         if ibytes is None:
             ibytes = [TelegramField(ACK_BYTE)]
 
@@ -102,9 +98,7 @@ class ShortFrame(TelegramFrame):
     5. stop 0x16.
     """
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         fields, length = list(TelegramContainer(ibytes=ibytes)), 5
         if len(fields) != length:
             msg = f"the length is not equal to {length}"
@@ -154,9 +148,7 @@ class ControlFrame(TelegramFrame):
     9. stop 0x16.
     """
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         fields, length = list(TelegramContainer(ibytes=ibytes)), 9
         if len(fields) != length:
             msg = f"the length is not equal to {length}"
@@ -228,9 +220,7 @@ class LongFrame(TelegramFrame):
     10. stop 0x16.
     """
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         fields, length = list(TelegramContainer(ibytes=ibytes)), 10
         if len(fields) != length:
             msg = f"the length is not equal to {length}"

--- a/src/pymbus/telegrams/records.py
+++ b/src/pymbus/telegrams/records.py
@@ -1,7 +1,7 @@
-from collections.abc import Iterable
+"""M-Bus Telegram Data Record module."""
 
 from pymbus.telegrams.base import (
-    TelegramByteType,
+    TelegramBytesType,
     TelegramContainer,
 )
 from pymbus.telegrams.blocks import (
@@ -13,7 +13,7 @@ from pymbus.telegrams.blocks import (
 
 
 class TelegramRecord(TelegramContainer):
-    """Base Telegram Record class"""
+    """Base Telegram Record class."""
 
 
 class DataRecord(TelegramRecord):
@@ -21,7 +21,7 @@ class DataRecord(TelegramRecord):
 
     Typically encountered as Data Record Header (DRH).
 
-    The structure of the DR(H):
+    The structure of the DRH:
     -----------------
     |   DIB  |  VIB |
     -----------------
@@ -30,9 +30,7 @@ class DataRecord(TelegramRecord):
     VIB = Value Information Block.
     """
 
-    def __init__(
-        self, ibytes: None | Iterable[TelegramByteType] = None
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
         container = list(TelegramContainer(ibytes=ibytes))
 
         dib = DIB(ibytes=container)

--- a/tests/codes/test_vif_codes.py
+++ b/tests/codes/test_vif_codes.py
@@ -191,7 +191,7 @@ def test_ontime_vifcodes(vif: VIF, code_type: VIFC | None, unit: str):
         raise ValueError(msg)
 
     assert type(res) is code_type
-    assert res.UNIT == unit
+    assert unit == res.UNIT
 
 
 @pytest.mark.parametrize(

--- a/tests/telegrams/test_records.py
+++ b/tests/telegrams/test_records.py
@@ -3,7 +3,7 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from pymbus.exceptions import MBusLengthError
+from pymbus.exceptions import MBusError
 from pymbus.telegrams.blocks import (
     DataInformationBlock as DIB,
 )
@@ -22,14 +22,15 @@ class TestDataRecord:
                 DIB(ibytes=[0b0111_0000]),
                 VIB(ibytes=[0b0111_0000]),
                 does_not_raise(),
-            )
+            ),
+            ([-1], None, None, pytest.raises(MBusError)),
         ],
     )
     def test_dr_init(
         self,
         it: list[int],
-        dib: DIB,
-        vib: VIB,
+        dib: None | DIB,
+        vib: None | VIB,
         expectation: AbstractContextManager,
     ):
         with expectation:
@@ -37,3 +38,21 @@ class TestDataRecord:
 
             assert dr.dib == dib
             assert dr.vib == vib
+
+
+@pytest.mark.parametrize(
+    ("data", "answer"),
+    [
+        (
+            b"\x93\xff\x81m\x00\x00\x04\x8d\x00\x03",
+            [DIB(ibytes=[147, 255, 129, 109]), VIB(ibytes=[0])],
+        )
+    ],
+)
+def test_binary_data_parsing(data: bytes, answer: list):
+    dr = DR(ibytes=data)
+
+    blocks = [dr.dib, dr.vib]
+
+    assert dr.as_bytes() == data
+    assert blocks == answer


### PR DESCRIPTION
Chores done:

- bump the version in the pyproject.toml -> now it is v0.2.0, so the previous release is inconsistent.
- add more ruff rules -> more linting done: unused imports removed, code simplified
- add TelegramBytesType as `bytes | bytearray | Iterable[TelegramByteType]`
- add the "Installation" section in the README
- some typos fixed