### PR TITLE
Make container children classes non greedy in terms of data parsing.

### DIFF
--- a/src/pymbus/telegrams/base.py
+++ b/src/pymbus/telegrams/base.py
@@ -12,28 +12,33 @@ from collections.abc import Iterable, Iterator
 from pymbus.exceptions import MBusValidationError
 
 
-def _validate_byte(nbr: int) -> int:
-    """Validates an integer number to be a byte.
+def _validate_byte(number: int) -> int:
+    """Returns an integer if it is a byte.
 
     In Python, a byte must be in range(0, 256).
     This is the range for an 8-bit unsigned integer.
 
+    Parameters
+    ----------
+    number : int
+
     Raises
     ------
-    MbusError: `nbr` is out of the [0, 255] segment.
+    MbusValidationError
+        the `number` is out of the [0, 255] segment.
 
     Returns
     -------
-    int - the validated byte
+    int
     """
 
     try:
-        bytes([nbr])
+        bytes([number])
     except ValueError as e:
-        msg = f"{nbr} is not a valid byte"
+        msg = f"{number} is not a valid byte"
         raise MBusValidationError(msg) from e
 
-    return nbr
+    return number
 
 
 class TelegramField:
@@ -51,6 +56,9 @@ class TelegramField:
         if isinstance(other, TelegramField):
             other = other.byte
         return sbyte == other
+
+    def __int__(self) -> int:
+        return self.byte
 
     def __repr__(self) -> str:
         cls_name = type(self).__name__
@@ -81,6 +89,8 @@ class TelegramContainer:
 
     A telegram container consists of telegram fields
     and it is an iterable object, which may also be an iterator.
+
+    The container accepts incoming bytes in a greedy manner.
     """
 
     @classmethod
@@ -127,5 +137,43 @@ class TelegramContainer:
         cls_name = type(self).__name__
         return f"{cls_name}(ibytes={self._fields})"
 
+    @staticmethod
+    def _iterify(data: None | TelegramBytesType = None) -> Iterator:
+        return iter(data or [])
+
     def as_bytes(self) -> bytes:
-        return bytes(field.byte for field in self._fields)
+        """Return bytes as Python `bytes`."""
+
+        return bytes(self.as_ints())
+
+    def as_ints(self) -> list[int]:
+        """Return bytes as a list of integers."""
+
+        return [field.byte for field in self._fields]
+
+
+def extract_bytes(it: Iterable) -> list[int]:
+    """Return the list of integers from an iterable object.
+
+    Notes
+    -----
+    The items are validated except `TelegramField`s.
+
+    Parameters
+    ----------
+    it : Iterable
+
+    Raises
+    ------
+    MbusValidationError:
+        if any item is not a byte.
+
+    Returns
+    -------
+    list[int]
+    """
+
+    return [
+        item.byte if isinstance(item, TelegramField) else _validate_byte(item)
+        for item in it
+    ]

--- a/src/pymbus/telegrams/base.py
+++ b/src/pymbus/telegrams/base.py
@@ -57,6 +57,12 @@ class TelegramField:
             other = other.byte
         return sbyte == other
 
+    def __lt__(self, other: "int | TelegramField") -> bool:
+        sbyte = self.byte
+        if isinstance(other, TelegramField):
+            other = other.byte
+        return sbyte < other
+
     def __int__(self) -> int:
         return self.byte
 

--- a/src/pymbus/telegrams/base.py
+++ b/src/pymbus/telegrams/base.py
@@ -73,10 +73,11 @@ class TelegramField:
 
 TelegramByteType = int | TelegramField
 TelegramBytesType = bytes | bytearray | Iterable[TelegramByteType]
+TelegramByteIterableType = TelegramBytesType | Iterator[TelegramByteType]
 
 
 def _convert_to_telegram_fields(
-    ibytes: TelegramBytesType,
+    ibytes: TelegramByteIterableType,
 ) -> list[TelegramField]:
     return [
         ibyte if isinstance(ibyte, TelegramField) else TelegramField(ibyte)
@@ -111,7 +112,7 @@ class TelegramContainer:
         except ValueError as e:
             raise MBusValidationError(str(e)) from e
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         self._fields = _convert_to_telegram_fields(ibytes or [])
 
     def __eq__(self, other: object) -> bool:

--- a/src/pymbus/telegrams/blocks.py
+++ b/src/pymbus/telegrams/blocks.py
@@ -1,10 +1,12 @@
 """M-Bus Telegram Blocks module."""
 
+from collections.abc import Iterator
+
 from pymbus.exceptions import MBusLengthError
 from pymbus.telegrams.base import (
     TelegramBytesType,
     TelegramContainer,
-    TelegramField,
+    extract_bytes,
 )
 from pymbus.telegrams.fields import DataInformationField as DIF
 from pymbus.telegrams.fields import DataInformationFieldExtension as DIFE
@@ -16,7 +18,7 @@ ValueFieldType = VIF | VIFE
 
 
 class TelegramBlock(TelegramContainer):
-    """Base Telegram Block class"""
+    """Base Telegram Block class."""
 
 
 class DataInformationBlock(TelegramBlock):
@@ -38,39 +40,38 @@ class DataInformationBlock(TelegramBlock):
     MAX_DIFE_FRAMES = 10
 
     def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
-        container = list(TelegramContainer(ibytes=ibytes))
+        it = self._iterify(ibytes)
 
-        blocks = self._parse_blocks(container)
+        try:
+            blocks = self._parse_blocks(it)
+        except StopIteration as e:
+            msg = f"{ibytes!r} is invalid"
+            raise MBusLengthError(msg) from e
         dif = blocks[0]
         difes = blocks[1]
 
-        super().__init__(ibytes=container[: (len(difes) + 1)])
+        super().__init__(ibytes=extract_bytes([dif] + difes))
         self._dif = dif
         self._difes = difes
 
-    def _parse_blocks(
-        self, fields: list[TelegramField]
-    ) -> tuple[DIF, list[DIFE]]:
-        cls_name = type(self)
-
-        if len(fields) < 1:
-            msg = f"no telegrams for {cls_name}"
-            raise MBusLengthError(msg)
-
-        dif = DIF(byte=fields[0].byte)
+    def _parse_blocks(self, it: Iterator) -> tuple[DIF, list[DIFE]]:
+        value: int = int(next(it))
+        dif = DIF(byte=value)
         if not dif.extension:
             return (dif, [])
 
         difes: list[DIFE] = []
         max_frame = self.MAX_DIFE_FRAMES + 1
-        pos = 1
-        while byte := fields[pos].byte:
-            dife = DIFE(byte=byte)
+        dife_counter = 1
+        while True:
+            value = int(next(it))
+            dife = DIFE(byte=value)
             difes.append(dife)
             if not dife.extension:
                 break
-            pos += 1
-            if pos == max_frame:
+
+            dife_counter += 1
+            if dife_counter == max_frame:
                 if dife.extension:
                     msg = f"the last {dife} has the extension bit set"
                     raise MBusLengthError(msg)
@@ -79,10 +80,14 @@ class DataInformationBlock(TelegramBlock):
 
     @property
     def dif(self) -> DIF:
+        """Return the DIF field."""
+
         return self._dif
 
     @property
     def difes(self) -> list[DIFE]:
+        """Return the list of DIFE fields."""
+
         return self._difes
 
 
@@ -108,39 +113,37 @@ class ValueInformationBlock(TelegramBlock):
     MAX_VIFE_FRAMES = 10
 
     def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
-        container = list(TelegramContainer(ibytes=ibytes))
+        it = self._iterify(ibytes)
 
-        blocks = self._parse_blocks(container)
+        try:
+            blocks = self._parse_blocks(it)
+        except StopIteration as e:
+            msg = f"{ibytes!r} is invalid"
+            raise MBusLengthError(msg) from e
         vif = blocks[0]
         vifes = blocks[1]
 
-        super().__init__(ibytes=container[: (len(vifes) + 1)])
+        super().__init__(ibytes=extract_bytes([vif] + vifes))
         self._vif = vif
         self._vifes = vifes
 
-    def _parse_blocks(
-        self, fields: list[TelegramField]
-    ) -> tuple[VIF, list[VIFE]]:
-        cls_name = type(self)
-
-        if len(fields) < 1:
-            msg = f"no telegrams for {cls_name}"
-            raise MBusLengthError(msg)
-
-        vif = VIF(byte=fields[0].byte)
+    def _parse_blocks(self, it: Iterator) -> tuple[VIF, list[VIFE]]:
+        value: int = int(next(it))
+        vif = VIF(byte=value)
         if not vif.extension:
             return (vif, [])
 
         vifes: list[VIFE] = []
         max_frame = self.MAX_VIFE_FRAMES + 1
-        pos = 1
-        while byte := fields[pos].byte:
-            vife = VIFE(byte=byte)
+        vife_counter = 1
+        while True:
+            value = int(next(it))
+            vife = VIFE(byte=value)
             vifes.append(vife)
             if not vife.extension:
                 break
-            pos += 1
-            if pos == max_frame:
+            vife_counter += 1
+            if vife_counter == max_frame:
                 if vife.extension:
                     msg = f"the last {vife} has the extension bit set"
                     raise MBusLengthError(msg)
@@ -149,8 +152,12 @@ class ValueInformationBlock(TelegramBlock):
 
     @property
     def vif(self) -> VIF:
+        """Return the VIF field."""
+
         return self._vif
 
     @property
     def vifes(self) -> list[VIFE]:
+        """Return the list of VIFE fields."""
+
         return self._vifes

--- a/src/pymbus/telegrams/blocks.py
+++ b/src/pymbus/telegrams/blocks.py
@@ -4,7 +4,7 @@ from collections.abc import Iterator
 
 from pymbus.exceptions import MBusLengthError
 from pymbus.telegrams.base import (
-    TelegramBytesType,
+    TelegramByteIterableType,
     TelegramContainer,
     extract_bytes,
 )
@@ -39,7 +39,7 @@ class DataInformationBlock(TelegramBlock):
 
     MAX_DIFE_FRAMES = 10
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         it = self._iterify(ibytes)
 
         try:
@@ -112,7 +112,7 @@ class ValueInformationBlock(TelegramBlock):
 
     MAX_VIFE_FRAMES = 10
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         it = self._iterify(ibytes)
 
         try:

--- a/src/pymbus/telegrams/blocks.py
+++ b/src/pymbus/telegrams/blocks.py
@@ -43,7 +43,7 @@ class DataInformationBlock(TelegramBlock):
         it = self._iterify(ibytes)
 
         try:
-            blocks = self._parse_blocks(it)
+            blocks = self._parse(it)
         except StopIteration as e:
             msg = f"{ibytes!r} is invalid"
             raise MBusLengthError(msg) from e
@@ -54,7 +54,7 @@ class DataInformationBlock(TelegramBlock):
         self._dif = dif
         self._difes = difes
 
-    def _parse_blocks(self, it: Iterator) -> tuple[DIF, list[DIFE]]:
+    def _parse(self, it: Iterator) -> tuple[DIF, list[DIFE]]:
         value: int = int(next(it))
         dif = DIF(byte=value)
         if not dif.extension:
@@ -116,7 +116,7 @@ class ValueInformationBlock(TelegramBlock):
         it = self._iterify(ibytes)
 
         try:
-            blocks = self._parse_blocks(it)
+            blocks = self._parse(it)
         except StopIteration as e:
             msg = f"{ibytes!r} is invalid"
             raise MBusLengthError(msg) from e
@@ -127,7 +127,7 @@ class ValueInformationBlock(TelegramBlock):
         self._vif = vif
         self._vifes = vifes
 
-    def _parse_blocks(self, it: Iterator) -> tuple[VIF, list[VIFE]]:
+    def _parse(self, it: Iterator) -> tuple[VIF, list[VIFE]]:
         value: int = int(next(it))
         vif = VIF(byte=value)
         if not vif.extension:

--- a/src/pymbus/telegrams/frames.py
+++ b/src/pymbus/telegrams/frames.py
@@ -6,12 +6,13 @@ The fields:
 - C = control
 - CI = control information
 - L = length
-
 """
+
+from collections.abc import Iterator
 
 from pymbus.exceptions import MBusLengthError, MBusValidationError
 from pymbus.telegrams.base import (
-    TelegramBytesType,
+    TelegramByteIterableType,
     TelegramContainer,
     TelegramField,
 )
@@ -62,14 +63,13 @@ class SingleFrame(TelegramFrame):
 
         return SingleFrame([byte])
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         if ibytes is None:
             ibytes = [TelegramField(ACK_BYTE)]
 
         fields = list(TelegramContainer(ibytes=ibytes))
         if len(fields) != 1:
-            cls_name = type(self).__name__
-            msg = f"{cls_name} accepts only {ACK_BYTE}"
+            msg = f"accepts only {ACK_BYTE}"
             raise MBusLengthError(msg)
 
         if (byte := fields[0].byte) != ACK_BYTE:
@@ -98,34 +98,36 @@ class ShortFrame(TelegramFrame):
     5. stop 0x16.
     """
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
-        fields, length = list(TelegramContainer(ibytes=ibytes)), 5
-        if len(fields) != length:
-            msg = f"the length is not equal to {length}"
-            raise MBusLengthError(msg)
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
+        it = iter(ibytes)  # type: ignore [arg-type]
+        try:
+            super().__init__(self._parse(it))
+        except StopIteration as e:
+            msg = f"{ibytes!r} are of invalid length"
+            raise MBusLengthError(msg) from e
 
-        cls_name = type(self).__name__
-        start_field = fields[0]
+    def _parse(self, it: Iterator) -> list[TelegramField]:
+        start_field = TelegramField(int(next(it)))
         if (byte := start_field.byte) != SHORT_FRAME_START_BYTE:
-            msg = f"the first byte {byte!r} is an invalid {cls_name} start byte"
-            raise MBusValidationError(msg)
-        control_field = ControlField(fields[1].byte)
-        address_field = AddressField(fields[2].byte)
-        check_sum_field = TelegramField(fields[3].byte)
-        stop_field = fields[4]
-        if (byte := stop_field.byte) != FRAME_STOP_BYTE:
-            msg = f"the fifth byte {byte!r} is an invalid {cls_name} stop byte"
+            msg = f"the first byte {byte!r} is an invalid start byte"
             raise MBusValidationError(msg)
 
-        super().__init__(
-            [
-                start_field,
-                control_field,
-                address_field,
-                check_sum_field,
-                stop_field,
-            ]
-        )
+        control_field = ControlField(int(next(it)))
+        address_field = AddressField(int(next(it)))
+        check_sum_field = TelegramField(int(next(it)))
+
+        stop_field = TelegramField(int(next(it)))
+        if (byte := stop_field.byte) != FRAME_STOP_BYTE:
+            msg = f"the fifth byte {byte!r} is an invalid stop byte"
+            raise MBusValidationError(msg)
+
+        return [
+            start_field,
+            control_field,
+            address_field,
+            check_sum_field,
+            stop_field,
+        ]
 
 
 class ControlFrame(TelegramFrame):
@@ -148,49 +150,49 @@ class ControlFrame(TelegramFrame):
     9. stop 0x16.
     """
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
-        fields, length = list(TelegramContainer(ibytes=ibytes)), 9
-        if len(fields) != length:
-            msg = f"the length is not equal to {length}"
-            raise MBusLengthError(msg)
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
+        it = iter(ibytes)  # type: ignore [arg-type]
+        try:
+            super().__init__(self._parse(it))
+        except StopIteration as e:
+            msg = f"{ibytes!r} are of invalid length"
+            raise MBusLengthError(msg) from e
 
-        cls_name = type(self).__name__
-        start_field = fields[0]
+    def _parse(self, it: Iterator) -> list[TelegramField]:
+        start_field = TelegramField(int(next(it)))
         if (byte := start_field.byte) != CONTROL_FRAME_START_BYTE:
-            msg = f"the first byte {byte!r} is invalid {cls_name} start byte"
+            msg = f"the first byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        length1_field = TelegramField(fields[1].byte)
-        length2_field = TelegramField(fields[2].byte)
+        length1_field = TelegramField(int(next(it)))
+        length2_field = TelegramField(int(next(it)))
 
-        start2_field = fields[3]
+        start2_field = TelegramField(int(next(it)))
         if (byte := start2_field.byte) != CONTROL_FRAME_START_BYTE:
-            msg = f"the fourth byte {byte!r} is invalid {cls_name} start byte"
+            msg = f"the fourth byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        control_field = ControlField(fields[4].byte)
-        address_field = AddressField(fields[5].byte)
-        control_info_field = ControlInformationField(fields[6].byte)
-        check_sum_field = TelegramField(fields[7].byte)
+        control_field = ControlField(int(next(it)))
+        address_field = AddressField(int(next(it)))
+        control_info_field = ControlInformationField(int(next(it)))
+        check_sum_field = TelegramField(int(next(it)))
 
-        stop_field = fields[8]
+        stop_field = TelegramField(int(next(it)))
         if (byte := stop_field.byte) != FRAME_STOP_BYTE:
-            msg = f"the ninth byte {byte!r} is invalid {cls_name} stop byte"
+            msg = f"the ninth byte {byte!r} is invalid stop byte"
             raise MBusValidationError(msg)
 
-        super().__init__(
-            [
-                start_field,
-                length1_field,
-                length2_field,
-                start2_field,
-                control_field,
-                address_field,
-                control_info_field,
-                check_sum_field,
-                stop_field,
-            ]
-        )
+        return [
+            start_field,
+            length1_field,
+            length2_field,
+            start2_field,
+            control_field,
+            address_field,
+            control_info_field,
+            check_sum_field,
+            stop_field,
+        ]
 
 
 class LongFrame(TelegramFrame):
@@ -220,55 +222,53 @@ class LongFrame(TelegramFrame):
     10. stop 0x16.
     """
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
-        fields, length = list(TelegramContainer(ibytes=ibytes)), 10
-        if len(fields) != length:
-            msg = f"the length is not equal to {length}"
-            raise MBusLengthError(msg)
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
+        it = iter(ibytes)  # type: ignore [arg-type]
+        try:
+            super().__init__(self._parse(it))
+        except StopIteration as e:
+            msg = f"{ibytes!r} are of invalid length"
+            raise MBusLengthError(msg) from e
 
-        cls_name = type(self).__name__
-        start_field = fields[0]
+    def _parse(self, it: Iterator) -> list[TelegramField]:
+        start_field = TelegramField(int(next(it)))
         if (byte := start_field.byte) != CONTROL_FRAME_START_BYTE:
-            msg = f"the first byte {byte!r} is invalid {cls_name} start byte"
+            msg = f"the first byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        length1_field = TelegramField(fields[1].byte)
-        length2_field = TelegramField(fields[2].byte)
+        length1_field = TelegramField(int(next(it)))
+        length2_field = TelegramField(int(next(it)))
 
-        start2_field = fields[3]
+        start2_field = TelegramField(int(next(it)))
         if (byte := start2_field.byte) != CONTROL_FRAME_START_BYTE:
-            msg = f"the fourth byte {byte!r} is invalid {cls_name} start byte"
+            msg = f"the fourth byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        control_field = ControlField(fields[4].byte)
-        address_field = AddressField(fields[5].byte)
-        control_info_field = ControlInformationField(fields[6].byte)
+        control_field = ControlField(int(next(it)))
+        address_field = AddressField(int(next(it)))
+        control_info_field = ControlInformationField(int(next(it)))
 
-        if not (0 <= (user_byte := fields[7].byte) <= 252):
-            msg = (
-                f"the eighth byte {byte!r} is invalid {cls_name} user data byte"
-            )
+        if not (0 <= (user_byte := int(next(it))) <= 252):
+            msg = f"the eighth byte {user_byte!r} is invalid user data byte"
             raise MBusValidationError(msg)
         user_data_field = TelegramField(user_byte)
 
-        check_sum_field = TelegramField(fields[8].byte)
+        check_sum_field = TelegramField(int(next(it)))
 
-        stop_field = fields[9]
+        stop_field = TelegramField(int(next(it)))
         if (byte := stop_field.byte) != FRAME_STOP_BYTE:
-            msg = f"the tenth byte {byte!r} is invalid {cls_name} stop byte"
+            msg = f"the tenth byte {byte!r} is invalid stop byte"
             raise MBusValidationError(msg)
 
-        super().__init__(
-            [
-                start_field,
-                length1_field,
-                length2_field,
-                start2_field,
-                control_field,
-                address_field,
-                control_info_field,
-                user_data_field,
-                check_sum_field,
-                stop_field,
-            ]
-        )
+        return [
+            start_field,
+            length1_field,
+            length2_field,
+            start2_field,
+            control_field,
+            address_field,
+            control_info_field,
+            user_data_field,
+            check_sum_field,
+            stop_field,
+        ]

--- a/src/pymbus/telegrams/records.py
+++ b/src/pymbus/telegrams/records.py
@@ -1,9 +1,6 @@
 """M-Bus Telegram Data Record module."""
 
-from pymbus.telegrams.base import (
-    TelegramBytesType,
-    TelegramContainer,
-)
+from pymbus.telegrams.base import TelegramByteIterableType, TelegramContainer
 from pymbus.telegrams.blocks import (
     DataInformationBlock as DIB,
 )
@@ -12,14 +9,8 @@ from pymbus.telegrams.blocks import (
 )
 
 
-class TelegramRecord(TelegramContainer):
-    """Base Telegram Record class."""
-
-
-class DataRecord(TelegramRecord):
-    """The "Data Record" (DR) class.
-
-    Typically encountered as Data Record Header (DRH).
+class DataRecordHeader(TelegramContainer):
+    """The "Data Record Header" (DRH) class.
 
     The structure of the DRH:
     -----------------
@@ -30,20 +21,25 @@ class DataRecord(TelegramRecord):
     VIB = Value Information Block.
     """
 
-    def __init__(self, ibytes: None | TelegramBytesType = None) -> None:
-        container = list(TelegramContainer(ibytes=ibytes))
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
+        it = iter(ibytes)  # type: ignore [arg-type]
 
-        dib = DIB(ibytes=container)
-        vib = VIB(ibytes=container[len(dib) :])
+        dib = DIB(ibytes=it)
+        vib = VIB(ibytes=it)
 
-        super().__init__(ibytes=container)
+        fields = list(dib) + list(vib)
+        super().__init__(ibytes=fields)
         self._dib = dib
         self._vib = vib
 
     @property
     def dib(self) -> DIB:
+        """Return DI block."""
+
         return self._dib
 
     @property
     def vib(self) -> VIB:
+        """Return VI block."""
+
         return self._vib

--- a/tests/telegrams/test_base.py
+++ b/tests/telegrams/test_base.py
@@ -5,8 +5,10 @@ import pytest
 
 from pymbus.exceptions import MBusError
 from pymbus.telegrams.base import (
+    TelegramBytesType,
     TelegramContainer,
     TelegramField,
+    extract_bytes,
 )
 
 
@@ -42,6 +44,14 @@ class TestTelegramField:
         tf = TelegramField(nbr)
 
         assert tf.byte == nbr
+
+    def test_int_conversion(self):
+        nbr = 21
+
+        result = int(TelegramField(nbr))
+
+        assert isinstance(result, int)
+        assert result == nbr
 
 
 class TestTelegramContainer:
@@ -90,3 +100,20 @@ class TestTelegramContainer:
         bytez = bytes(tf.byte for tf in tc)
 
         assert tc.as_bytes() == bytez
+
+    def test_as_ints(self):
+        ints = [0, 1, 2]
+
+        tc = TelegramContainer(ints)
+
+        assert tc.as_ints() == ints
+
+
+@pytest.mark.parametrize(
+    ("it", "answer"),
+    [([], []), ([0, TelegramField(byte=42), 0b1111_1111], [0, 42, 255])],
+)
+def test_extract_bytes(it: TelegramBytesType, answer: list[int]) -> None:
+    bytez = extract_bytes(it)
+
+    assert bytez == answer

--- a/tests/telegrams/test_blocks.py
+++ b/tests/telegrams/test_blocks.py
@@ -22,7 +22,7 @@ class TestDIB:
             ([0b1000_1111, 0b0111_0000], does_not_raise()),
         ],
     )
-    def test_dib_init_from_integers(
+    def test_init_from_integers(
         self, ints: list[int], expectation: AbstractContextManager
     ):
         with expectation:
@@ -35,7 +35,7 @@ class TestDIB:
             ("8f 70", does_not_raise()),
         ],
     )
-    def test_dib_init_from_hexstring(
+    def test_init_from_hexstring(
         self, hexstr: str, expectation: AbstractContextManager
     ):
         with expectation:
@@ -82,24 +82,30 @@ class TestDIB:
             ),
         ],
     )
-    def test_dib_init(
-        self, ints: list[int], expectation: AbstractContextManager
-    ):
+    def test_init(self, ints: list[int], expectation: AbstractContextManager):
         with expectation:
             DIB(ints)
 
-    def test_dib_iterability(self):
+    def test_iterability(self):
         it = [0b1000_0000, 0b1000_0001, 0b0111_0010]
         dib = DIB(it)
 
         for df, byte in zip(dib, it, strict=True):
             assert df.byte == byte
 
-    def test_dib_fields_init_non_greedy_capture(self):
-        it = [0b1000_0000, 0b1000_0001, 0b0111_0010]
-        dib = DIB(it)
+    @pytest.mark.parametrize(
+        ("it", "nbytes"),
+        [
+            ([0b1000_0000, 0b1000_0001, 0b0111_0010], 3),
+            ([0b1000_0000, 0b0000_0000, 0b1111_1111], 2),
+        ],
+    )
+    def test_non_greediness(self, it: list[int], nbytes: int):
+        gen = (el for el in it)
+        dib = DIB(gen)
 
-        assert list(dib) == it
+        assert list(dib) == it[:nbytes]
+        assert list(gen) == it[nbytes:]
 
 
 class TestVIB:
@@ -112,7 +118,7 @@ class TestVIB:
             ([0b1000_1111, 0b0111_0000], does_not_raise()),
         ],
     )
-    def test_vib_init_from_integers(
+    def test_init_from_integers(
         self, ints: list[int], expectation: AbstractContextManager
     ):
         with expectation:
@@ -125,7 +131,7 @@ class TestVIB:
             ("8f 70", does_not_raise()),
         ],
     )
-    def test_vib_init_from_hexstring(
+    def test_init_from_hexstring(
         self, hexstr: str, expectation: AbstractContextManager
     ):
         with expectation:
@@ -172,21 +178,27 @@ class TestVIB:
             ),
         ],
     )
-    def test_vib_init(
-        self, ints: list[int], expectation: AbstractContextManager
-    ):
+    def test_init(self, ints: list[int], expectation: AbstractContextManager):
         with expectation:
             VIB(ints)
 
-    def test_vib_iterability(self):
+    def test_iterability(self):
         it = [0b1000_0000, 0b1000_0001, 0b0111_0010]
         vib = VIB(it)
 
         for df, byte in zip(vib, it, strict=True):
             assert df.byte == byte
 
-    def test_vib_fields_init_non_greedy_capture(self):
-        it = [0b1000_0000, 0b1000_0001, 0b0111_0010]
-        vib = VIB(it)
+    @pytest.mark.parametrize(
+        ("it", "nbytes"),
+        [
+            ([0b1000_0000, 0b1000_0001, 0b0111_0010], 3),
+            ([0b1000_0000, 0b0000_0000, 0b1111_1111], 2),
+        ],
+    )
+    def test_non_greediness(self, it: list[int], nbytes: int):
+        gen = (el for el in it)
+        dib = DIB(gen)
 
-        assert list(vib) == it
+        assert list(dib) == it[:nbytes]
+        assert list(gen) == it[nbytes:]

--- a/tests/telegrams/test_frames.py
+++ b/tests/telegrams/test_frames.py
@@ -29,9 +29,7 @@ class TestSingleFrame:
             ([ACK_BYTE, ACK_BYTE], pytest.raises(MBusLengthError)),
         ],
     )
-    def test_single_frame_init(
-        self, it: list[int], expectation: AbstractContextManager
-    ):
+    def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
             SingleFrame.from_integers(it)
 
@@ -70,14 +68,20 @@ class TestShortFrame:
             ),
         ],
     )
-    def test_short_frame_init(
-        self, it: list[int], expectation: AbstractContextManager
-    ):
+    def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
             ShortFrame.from_integers(it)
 
         with expectation:
             ShortFrame(it)
+
+    def test_non_greediness(self):
+        it = [SHORT_FRAME_START_BYTE, 2, 3, 4, FRAME_STOP_BYTE, 5]
+        gen = (b for b in it)
+
+        ShortFrame(gen)
+
+        assert list(gen) == [5]
 
 
 ## Control Frame section
@@ -125,14 +129,31 @@ class TestControlFrame:
             ),
         ],
     )
-    def test_control_frame_init(
-        self, it: list[int], expectation: AbstractContextManager
-    ):
+    def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
             ControlFrame.from_integers(it)
 
         with expectation:
             ControlFrame(it)
+
+    def test_non_greediness(self):
+        it = [
+            CONTROL_FRAME_START_BYTE,
+            1,
+            2,
+            CONTROL_FRAME_START_BYTE,
+            4,
+            5,
+            6,
+            7,
+            FRAME_STOP_BYTE,
+            21,
+        ]
+        gen = (b for b in it)
+
+        ControlFrame(gen)
+
+        assert list(gen) == [21]
 
 
 ## Long Frame section
@@ -197,11 +218,29 @@ class TestLongFrame:
             ),
         ],
     )
-    def test_long_frame_init(
-        self, it: list[int], expectation: AbstractContextManager
-    ):
+    def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
             LongFrame.from_integers(it)
 
         with expectation:
             LongFrame(it)
+
+    def test_non_greediness(self):
+        it = [
+            LONG_FRAME_START_BYTE,
+            1,
+            2,
+            LONG_FRAME_START_BYTE,
+            4,
+            5,
+            6,
+            252,  # user data
+            7,
+            FRAME_STOP_BYTE,
+            42,
+        ]
+        gen = (b for b in it)
+
+        LongFrame(gen)
+
+        assert list(gen) == [42]


### PR DESCRIPTION
The `TelegramContainer` class is OK to be greedy - it is generic and M-Bus-agnostic. However, its children like blocks, frames and so on should not be as greedy as their parent. The rationale is data may be exhaustible like generator objects, streams and so on. In this case a common data source may be conveyed into the `TelegramContainer` children class instances pipeline and each must accept only intended slice of data. A good example is `DataRecordHeader` consisiting of DIB and VIB which only eat only their portion of data and the rest of the latter may be consumed elsewhere.

Also, the `DataRecord` class is renamed to `DataRecordHeader` (DRH) because `DataRecord` may be meant to consists of DRH and associated data.