### PR TITLE
Subclass telegram field from the `int` class.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
+      # https://github.com/astral-sh/setup-uv
       - name: Install UV
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
+          activate-environment: true
+          enable-cache: true
+          ignore-nothing-to-cache: true
           python-version: ${{ matrix.python-version }}
 
       - name: Install PyMBus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## v0.4.0
 
-- Specific Telegram fields (A, C, CI, Data, Value) are submoduled ([PR-12](https://github.com/stankudrow/pymbus/pull/12)).
+- subclass the TelegramField class from Python int type ([PR-15](https://github.com/stankudrow/pymbus/pull/15)):
+  - make TelegramField support the operations that `int` does;
+  - ensure the byte range validation for TelegramField -> the `validate` flag removed;
+  - unburden and simplify TelegramField successors and classes derived from TelegramContainer;
+  - revises with enhancements the [PR-11](https://github.com/stankudrow/pymbus/pull/11).
+- submodule specific Telegram fields (A, C, CI, Data, Value) ([PR-12](https://github.com/stankudrow/pymbus/pull/12)).
 - improve Telegram classes ([PR-11](https://github.com/stankudrow/pymbus/pull/11)):
   - the API of TelegramField is enriched:
     - `total_ordering` is enabled - the full set of arithmetic comparison operators are on

--- a/src/pymbus/codes/vif.py
+++ b/src/pymbus/codes/vif.py
@@ -265,7 +265,7 @@ def get_vif_code(byte: int | VIF) -> None | VIFCode:  # noqa: C901
     None | ValueInformationFieldCode
     """
 
-    vif = VIF(int(byte), validate=True)
+    vif = VIF(int(byte))
     if vif < 0x08:  # Energy (Wh) -> E000_0nnn
         return EnergyWattHourVIFCode(vif)
     if vif < 0x10:  # Energy (J) -> E000_1nnn

--- a/src/pymbus/telegrams/base.py
+++ b/src/pymbus/telegrams/base.py
@@ -15,54 +15,19 @@ from pymbus.utils import validate_byte
 
 
 @total_ordering
-class TelegramField:
+class TelegramField(int):
     """The base "Field" class.
 
-    It is a base wrapper over a byte value.
+    Restricts int values to the byte range [0, 255].
+    Supports all operations that the `int` class does.
     """
 
-    def __init__(self, byte: int, *, validate: bool = False) -> None:
-        self._byte = validate_byte(byte) if validate else byte
-
-    def __and__(self, other: "int | TelegramField") -> int:
-        if isinstance(other, TelegramField):
-            other = other._byte
-        return self._byte & other
-
-    def __bool__(self) -> bool:
-        return bool(self._byte)
-
-    def __eq__(self, other: object) -> bool:
-        sbyte = self._byte
-        if isinstance(other, TelegramField):
-            other = other._byte
-        return sbyte == other
-
-    def __int__(self) -> int:
-        return self._byte
-
-    def __invert__(self) -> int:
-        return ~self._byte
-
-    def __lt__(self, other: "int | TelegramField") -> bool:
-        sbyte = self._byte
-        if isinstance(other, TelegramField):
-            other = other._byte
-        return sbyte < other
-
-    def __or__(self, other: "int | TelegramField") -> int:
-        if isinstance(other, TelegramField):
-            other = other._byte
-        return self._byte | other
+    def __init__(self, byte: int) -> None:
+        self._byte = validate_byte(byte)
 
     def __repr__(self) -> str:
         cls_name = type(self).__name__
-        return f"{cls_name}(byte={self._byte})"
-
-    def __xor__(self, other: "int | TelegramField") -> int:
-        if isinstance(other, TelegramField):
-            other = other._byte
-        return self._byte ^ other
+        return f"{cls_name}({self._byte})"
 
 
 TelegramByteType = int | TelegramField
@@ -74,8 +39,8 @@ TelegramByteIterableType = TelegramBytesType | Iterator[TelegramByteType]
 class TelegramContainer:
     """The base class for Telegram containers.
 
-    TelegramContainer consists of telegram fields.
-    When being instantiated, the incomin bytes are consumed greedily.
+    A telegram container consists of telegram fields.
+    When being instantiated, the incoming bytes are consumed greedily.
     """
 
     @classmethod
@@ -90,13 +55,9 @@ class TelegramContainer:
     def __init__(
         self,
         ibytes: None | TelegramByteIterableType = None,
-        *,
-        validate: bool = False,
     ) -> None:
         self._fields: list[TelegramField] = (
-            [TelegramField(int(ibyte), validate=validate) for ibyte in ibytes]
-            if ibytes
-            else []
+            [TelegramField(ibyte) for ibyte in ibytes] if ibytes else []
         )
 
     def __eq__(self, other: object) -> bool:
@@ -126,4 +87,4 @@ class TelegramContainer:
 
     def __repr__(self) -> str:
         cls_name = type(self).__name__
-        return f"{cls_name}(ibytes={self._fields})"
+        return f"{cls_name}({self._fields})"

--- a/src/pymbus/telegrams/blocks.py
+++ b/src/pymbus/telegrams/blocks.py
@@ -41,13 +41,11 @@ class DataInformationBlock(TelegramBlock):
     def __init__(
         self,
         ibytes: None | TelegramByteIterableType = None,
-        *,
-        validate: bool = False,
     ) -> None:
         it = iter(ibytes if ibytes else [])
 
         try:
-            blocks = self._parse(it, validate=validate)
+            blocks = self._parse(it)
         except StopIteration as e:
             msg = f"{ibytes!r} has invalid length"
             raise MBusLengthError(msg) from e
@@ -59,11 +57,9 @@ class DataInformationBlock(TelegramBlock):
         self._dif = dif
         self._difes = difes
 
-    def _parse(
-        self, it: Iterator, *, validate: bool = False
-    ) -> tuple[DIF, list[DIFE]]:
+    def _parse(self, it: Iterator) -> tuple[DIF, list[DIFE]]:
         value: int = int(next(it))
-        dif = DIF(byte=value, validate=validate)
+        dif = DIF(value)
         if not dif.extension:
             return (dif, [])
 
@@ -72,7 +68,7 @@ class DataInformationBlock(TelegramBlock):
         dife_counter = 1
         while True:
             value = int(next(it))
-            dife = DIFE(byte=value, validate=validate)
+            dife = DIFE(value)
             difes.append(dife)
             if not dife.extension:
                 break
@@ -119,16 +115,11 @@ class ValueInformationBlock(TelegramBlock):
 
     MAX_VIFE_FRAMES = 10
 
-    def __init__(
-        self,
-        ibytes: None | TelegramByteIterableType = None,
-        *,
-        validate: bool = False,
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         it = iter(ibytes if ibytes else [])
 
         try:
-            blocks = self._parse(it, validate=validate)
+            blocks = self._parse(it)
         except StopIteration as e:
             msg = f"{ibytes!r} has invalid length"
             raise MBusLengthError(msg) from e
@@ -139,11 +130,9 @@ class ValueInformationBlock(TelegramBlock):
         self._vif = vif
         self._vifes = vifes
 
-    def _parse(
-        self, it: Iterator, *, validate: bool = False
-    ) -> tuple[VIF, list[VIFE]]:
+    def _parse(self, it: Iterator) -> tuple[VIF, list[VIFE]]:
         value: int = int(next(it))
-        vif = VIF(byte=value, validate=validate)
+        vif = VIF(value)
         if not vif.extension:
             return (vif, [])
 
@@ -152,7 +141,7 @@ class ValueInformationBlock(TelegramBlock):
         vife_counter = 1
         while True:
             value = int(next(it))
-            vife = VIFE(byte=value, validate=validate)
+            vife = VIFE(value)
             vifes.append(vife)
             if not vife.extension:
                 break

--- a/src/pymbus/telegrams/fields/control.py
+++ b/src/pymbus/telegrams/fields/control.py
@@ -60,8 +60,8 @@ class ControlField(TelegramField):
     CF_FCB_OR_ACD_MASK = 0x20
     CF_FCV_OR_DFC_MASK = 0x10
 
-    def __init__(self, byte: int, *, validate: bool = False) -> None:
-        super().__init__(byte, validate=validate)
+    def __init__(self, byte: int) -> None:
+        super().__init__(byte)
 
         self._code = byte & self.CF_FUNCTION_CODE_MASK
         self._fcv_or_dfc = int((byte & self.CF_FCV_OR_DFC_MASK) != 0)

--- a/src/pymbus/telegrams/fields/data.py
+++ b/src/pymbus/telegrams/fields/data.py
@@ -19,8 +19,8 @@ class DataInformationField(TelegramField):
     EXTENSION_BIT_MASK = 0x80  # 0b1000_0000
     STORAGE_NUMBER_LSB_MASK = 0x40  # 0b0100_0000
 
-    def __init__(self, byte: int, *, validate: bool = False) -> None:
-        super().__init__(byte, validate=validate)
+    def __init__(self, byte: int) -> None:
+        super().__init__(byte)
 
         self._data = byte & self.DATA_FIELD_MASK
         self._func = (byte & self.FUNCTION_FIELD_MASK) >> 4
@@ -60,8 +60,8 @@ class DataInformationFieldExtension(TelegramField):
     STORAGE_NUMBER_MASK = 0x0F  # 0b0000_1111
     TARIFF_MASK = 0x30  # 0b0011_0000
 
-    def __init__(self, byte: int, *, validate: bool = False) -> None:
-        super().__init__(byte, validate=validate)
+    def __init__(self, byte: int) -> None:
+        super().__init__(byte)
 
         self._storage_number = byte & self.STORAGE_NUMBER_MASK
         self._tariff = (byte & self.TARIFF_MASK) >> 4

--- a/src/pymbus/telegrams/fields/value.py
+++ b/src/pymbus/telegrams/fields/value.py
@@ -17,8 +17,8 @@ class ValueInformationField(TelegramField):
     UNIT_AND_MULTIPLIER_MASK = 0x7F  # 0b0111_1111
     EXTENSION_BIT_MASK = 0x80  # 0b1000_0000
 
-    def __init__(self, byte: int, *, validate: bool = False) -> None:
-        super().__init__(byte, validate=validate)
+    def __init__(self, byte: int) -> None:
+        super().__init__(byte)
 
         self._data = byte & self.UNIT_AND_MULTIPLIER_MASK
         self._ext = int((byte & self.EXTENSION_BIT_MASK) != 0)
@@ -46,8 +46,8 @@ class ValueInformationFieldExtension(TelegramField):
     UNIT_AND_MULTIPLIER_MASK = 0x7F  # 0b0111_1111
     EXTENSION_BIT_MASK = 0x80  # 0b1000_0000
 
-    def __init__(self, byte: int, *, validate: bool = False) -> None:
-        super().__init__(byte, validate=validate)
+    def __init__(self, byte: int) -> None:
+        super().__init__(byte)
 
         self._data = byte & self.UNIT_AND_MULTIPLIER_MASK
         self._ext = int((byte & self.EXTENSION_BIT_MASK) != 0)

--- a/src/pymbus/telegrams/frames.py
+++ b/src/pymbus/telegrams/frames.py
@@ -63,17 +63,12 @@ class SingleFrame(TelegramFrame):
 
         return SingleFrame([byte])
 
-    def __init__(
-        self,
-        ibytes: None | TelegramByteIterableType = None,
-        *,
-        validate: bool = False,
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         fields = ibytes if ibytes else [TelegramField(ACK_BYTE)]
 
         it = iter(fields)
         try:
-            field = TelegramField(int(next(it)), validate=validate)
+            field = TelegramField(int(next(it)))
         except StopIteration as e:
             msg = f"empty byte sequence: {ibytes!r}"
             raise MBusLengthError(msg) from e
@@ -104,32 +99,25 @@ class ShortFrame(TelegramFrame):
     5. stop 0x16.
     """
 
-    def __init__(
-        self,
-        ibytes: None | TelegramByteIterableType = None,
-        *,
-        validate: bool = False,
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         it = iter(ibytes if ibytes else [])
         try:
-            super().__init__(self._parse(it, validate=validate))
+            super().__init__(self._parse(it))
         except StopIteration as e:
             msg = f"{ibytes!r} has an invalid length"
             raise MBusLengthError(msg) from e
 
-    def _parse(
-        self, it: Iterator, *, validate: bool = False
-    ) -> list[TelegramField]:
-        start_field = TelegramField(int(next(it)), validate=validate)
+    def _parse(self, it: Iterator) -> list[TelegramField]:
+        start_field = TelegramField(int(next(it)))
         if (byte := start_field) != SHORT_FRAME_START_BYTE:
             msg = f"the first byte {byte!r} is an invalid start byte"
             raise MBusValidationError(msg)
 
-        control_field = ControlField(int(next(it)), validate=validate)
-        address_field = AddressField(int(next(it)), validate=validate)
-        check_sum_field = TelegramField(int(next(it)), validate=validate)
+        control_field = ControlField(int(next(it)))
+        address_field = AddressField(int(next(it)))
+        check_sum_field = TelegramField(int(next(it)))
 
-        stop_field = TelegramField(int(next(it)), validate=validate)
+        stop_field = TelegramField(int(next(it)))
         if (byte := stop_field) != FRAME_STOP_BYTE:
             msg = f"the fifth byte {byte!r} is an invalid stop byte"
             raise MBusValidationError(msg)
@@ -163,43 +151,34 @@ class ControlFrame(TelegramFrame):
     9. stop 0x16.
     """
 
-    def __init__(
-        self,
-        ibytes: None | TelegramByteIterableType = None,
-        *,
-        validate: bool = False,
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         it = iter(ibytes if ibytes else [])
         try:
-            super().__init__(self._parse(it, validate=validate))
+            super().__init__(self._parse(it))
         except StopIteration as e:
             msg = f"{ibytes!r} has an invalid length"
             raise MBusLengthError(msg) from e
 
-    def _parse(
-        self, it: Iterator, *, validate: bool = False
-    ) -> list[TelegramField]:
-        start_field = TelegramField(int(next(it)), validate=validate)
+    def _parse(self, it: Iterator) -> list[TelegramField]:
+        start_field = TelegramField(int(next(it)))
         if (byte := start_field) != CONTROL_FRAME_START_BYTE:
             msg = f"the first byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        length1_field = TelegramField(int(next(it)), validate=validate)
-        length2_field = TelegramField(int(next(it)), validate=validate)
+        length1_field = TelegramField(int(next(it)))
+        length2_field = TelegramField(int(next(it)))
 
-        start2_field = TelegramField(int(next(it)), validate=validate)
+        start2_field = TelegramField(int(next(it)))
         if (byte := start2_field) != CONTROL_FRAME_START_BYTE:
             msg = f"the fourth byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        control_field = ControlField(int(next(it)), validate=validate)
-        address_field = AddressField(int(next(it)), validate=validate)
-        control_info_field = ControlInformationField(
-            int(next(it)), validate=validate
-        )
-        check_sum_field = TelegramField(int(next(it)), validate=validate)
+        control_field = ControlField(int(next(it)))
+        address_field = AddressField(int(next(it)))
+        control_info_field = ControlInformationField(int(next(it)))
+        check_sum_field = TelegramField(int(next(it)))
 
-        stop_field = TelegramField(int(next(it)), validate=validate)
+        stop_field = TelegramField(int(next(it)))
         if (byte := stop_field) != FRAME_STOP_BYTE:
             msg = f"the ninth byte {byte!r} is invalid stop byte"
             raise MBusValidationError(msg)
@@ -244,49 +223,40 @@ class LongFrame(TelegramFrame):
     10. stop 0x16.
     """
 
-    def __init__(
-        self,
-        ibytes: None | TelegramByteIterableType = None,
-        *,
-        validate: bool = False,
-    ) -> None:
+    def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
         it = iter(ibytes if ibytes else [])
         try:
-            super().__init__(self._parse(it, validate=validate))
+            super().__init__(self._parse(it))
         except StopIteration as e:
             msg = f"{ibytes!r} has an invalid length"
             raise MBusLengthError(msg) from e
 
-    def _parse(
-        self, it: Iterator, *, validate: bool = False
-    ) -> list[TelegramField]:
-        start_field = TelegramField(int(next(it)), validate=validate)
+    def _parse(self, it: Iterator) -> list[TelegramField]:
+        start_field = TelegramField(int(next(it)))
         if (byte := start_field) != CONTROL_FRAME_START_BYTE:
             msg = f"the first byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        length1_field = TelegramField(int(next(it)), validate=validate)
-        length2_field = TelegramField(int(next(it)), validate=validate)
+        length1_field = TelegramField(int(next(it)))
+        length2_field = TelegramField(int(next(it)))
 
-        start2_field = TelegramField(int(next(it)), validate=validate)
+        start2_field = TelegramField(int(next(it)))
         if (byte := start2_field) != CONTROL_FRAME_START_BYTE:
             msg = f"the fourth byte {byte!r} is invalid start byte"
             raise MBusValidationError(msg)
 
-        control_field = ControlField(int(next(it)), validate=validate)
-        address_field = AddressField(int(next(it)), validate=validate)
-        control_info_field = ControlInformationField(
-            int(next(it)), validate=validate
-        )
+        control_field = ControlField(int(next(it)))
+        address_field = AddressField(int(next(it)))
+        control_info_field = ControlInformationField(int(next(it)))
 
         if not (0 <= (user_byte := int(next(it))) <= 252):
             msg = f"the eighth byte {user_byte!r} is invalid user data byte"
             raise MBusValidationError(msg)
         user_data_field = TelegramField(user_byte)
 
-        check_sum_field = TelegramField(int(next(it)), validate=validate)
+        check_sum_field = TelegramField(int(next(it)))
 
-        stop_field = TelegramField(int(next(it)), validate=validate)
+        stop_field = TelegramField(int(next(it)))
         if (byte := stop_field) != FRAME_STOP_BYTE:
             msg = f"the tenth byte {byte!r} is invalid stop byte"
             raise MBusValidationError(msg)

--- a/src/pymbus/telegrams/records.py
+++ b/src/pymbus/telegrams/records.py
@@ -22,7 +22,7 @@ class DataRecordHeader(TelegramContainer):
     """
 
     def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
-        it = iter(ibytes)  # type: ignore [arg-type]
+        it = iter(ibytes if ibytes else [])
 
         dib = DIB(ibytes=it)
         vib = VIB(ibytes=it)
@@ -58,7 +58,7 @@ class DataRecord(TelegramContainer):
     """
 
     def __init__(self, ibytes: None | TelegramByteIterableType = None) -> None:
-        it = iter(ibytes)  # type: ignore [arg-type]
+        it = iter(ibytes if ibytes else [])
 
         drh = DataRecordHeader(ibytes=it)
         data = TelegramContainer(ibytes=it)

--- a/tests/telegrams/test_blocks.py
+++ b/tests/telegrams/test_blocks.py
@@ -69,7 +69,7 @@ class TestDIB:
     )
     def test_init(self, ints: list[int], expectation: AbstractContextManager):
         with expectation:
-            DIB(ints, validate=True)
+            DIB(ints)
 
     def test_iterability(self):
         it = [0b1000_0000, 0b1000_0001, 0b0111_0010]
@@ -150,7 +150,7 @@ class TestVIB:
     )
     def test_init(self, ints: list[int], expectation: AbstractContextManager):
         with expectation:
-            VIB(ints, validate=True)
+            VIB(ints)
 
     def test_iterability(self):
         it = [0b1000_0000, 0b1000_0001, 0b0111_0010]

--- a/tests/telegrams/test_fields.py
+++ b/tests/telegrams/test_fields.py
@@ -173,7 +173,7 @@ class TestDIF:
         ],
     )
     def test_dif_extension_bit(self, byte: int, ext_bit: int):
-        dif = DIF(byte=byte)
+        dif = DIF(byte)
 
         assert dif.extension == ext_bit
 
@@ -185,7 +185,7 @@ class TestDIF:
         ],
     )
     def test_dif_storage_number_lsb(self, byte: int, sn_lsb: int):
-        dif = DIF(byte=byte)
+        dif = DIF(byte)
 
         assert dif.storage_number_lsb == sn_lsb
 
@@ -199,7 +199,7 @@ class TestDIF:
         ],
     )
     def test_dif_function_field(self, byte: int, function_field: int):
-        dif = DIF(byte=byte)
+        dif = DIF(byte)
 
         assert dif.function == function_field
 
@@ -213,7 +213,7 @@ class TestDIF:
         ],
     )
     def test_dif_data_field(self, byte: int, data_field: int):
-        dif = DIF(byte=byte)
+        dif = DIF(byte)
 
         assert dif.data == data_field
 
@@ -227,7 +227,7 @@ class TestDIFE:
         ],
     )
     def test_dife_extension_bit(self, byte: int, ext_bit: int):
-        dif = DIFE(byte=byte)
+        dif = DIFE(byte)
 
         assert dif.extension == ext_bit
 
@@ -239,7 +239,7 @@ class TestDIFE:
         ],
     )
     def test_dife_storage_number_lsb(self, byte: int, device_unit: int):
-        dif = DIFE(byte=byte)
+        dif = DIFE(byte)
 
         assert dif.device_unit == device_unit
 
@@ -253,7 +253,7 @@ class TestDIFE:
         ],
     )
     def test_dife_tariff(self, byte: int, tariff: int):
-        dif = DIFE(byte=byte)
+        dif = DIFE(byte)
 
         assert dif.tariff == tariff
 
@@ -267,7 +267,7 @@ class TestDIFE:
         ],
     )
     def test_dife_storage_number(self, byte: int, storage_number: int):
-        dif = DIFE(byte=byte)
+        dif = DIFE(byte)
 
         assert dif.storage_number == storage_number
 
@@ -281,7 +281,7 @@ class TestVIF:
         ],
     )
     def test_vif_extension_bit(self, byte: int, ext_bit: int):
-        vif = VIF(byte=byte)
+        vif = VIF(byte)
 
         assert vif.extension == ext_bit
 
@@ -293,7 +293,7 @@ class TestVIF:
         ],
     )
     def test_vif_unit(self, byte: int, unit: int):
-        vif = VIF(byte=byte)
+        vif = VIF(byte)
 
         assert vif.unit == unit
 
@@ -307,7 +307,7 @@ class TestVIFE:
         ],
     )
     def test_vife_extension_bit(self, byte: int, ext_bit: int):
-        vife = VIFE(byte=byte)
+        vife = VIFE(byte)
 
         assert vife.extension == ext_bit
 
@@ -319,6 +319,6 @@ class TestVIFE:
         ],
     )
     def test_vife_unit(self, byte: int, unit: int):
-        vife = VIFE(byte=byte)
+        vife = VIFE(byte)
 
         assert vife.unit == unit

--- a/tests/telegrams/test_frames.py
+++ b/tests/telegrams/test_frames.py
@@ -31,7 +31,7 @@ class TestSingleFrame:
     )
     def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
-            SingleFrame(it, validate=True)
+            SingleFrame(it)
 
 
 ## Short Frame section
@@ -67,7 +67,7 @@ class TestShortFrame:
     )
     def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
-            ShortFrame(it, validate=True)
+            ShortFrame(it)
 
     def test_non_greediness(self):
         it = [SHORT_FRAME_START_BYTE, 2, 3, 4, FRAME_STOP_BYTE, 5]
@@ -125,7 +125,7 @@ class TestControlFrame:
     )
     def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
-            ControlFrame(it, validate=True)
+            ControlFrame(it)
 
     def test_non_greediness(self):
         it = [
@@ -211,7 +211,7 @@ class TestLongFrame:
     )
     def test_init(self, it: list[int], expectation: AbstractContextManager):
         with expectation:
-            LongFrame(it, validate=True)
+            LongFrame(it)
 
     def test_non_greediness(self):
         it = [


### PR DESCRIPTION
This will make the class easier, validating incoming `int` values is necessary because it integers are acceptable yet only from the byte range.