### PR TITLE
Remake main VIF code table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.4.0
 
+- remake VIF codes ([PR-17](https://github.com/stankudrow/pymbus/pull/17) + [PR-18](https://github.com/stankudrow/pymbus/pull/18)):
+  - only one VIFCode (data)class for coding;
+  - the `get_vif_code` factory method is improved.
 - subclass TelegramContainer from Sequence ABC ([PR-16](https://github.com/stankudrow/pymbus/pull/16))
 - subclass the TelegramField class from Python int type ([PR-15](https://github.com/stankudrow/pymbus/pull/15)):
   - make TelegramField support the operations that `int` does;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,9 +165,11 @@ fixable = ["I", "ICN", "ISC"]
 "{src,tests}/*.py" = [
     "N817",  # https://docs.astral.sh/ruff/rules/camelcase-imported-as-acronym/
 ]
+"src/pymbus/codes/vif.py" = ["ERA001"]
 "tests/*.py" = [
     "ANN201",  # https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/
     "D",
+    "ERA",
     "FBT001",  # https://docs.astral.sh/ruff/rules/boolean-type-hint-positional-argument/
     "PT011",  # https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
     "S",

--- a/src/pymbus/codes/vif.py
+++ b/src/pymbus/codes/vif.py
@@ -5,99 +5,143 @@ from pymbus.telegrams.fields import ValueInformationField as VIF
 
 
 class VIFCode:
-    CMASK: int  # coding mask
-    RCMASK: int = 0  # range coding mask
+    """VIF Code generic class.
+
+    Attributes
+    ----------
+    CMASK : int
+        coding mask - valid positions in the VIF code table
+    RMASK : int, default 0
+        range coding mask - useful for range VIF codes
+    UNIT : str, default ""
+        a unit of measurement for the class
+        individual codes may define own unit subclass
+    """
+
+    CMASK: int
+    RMASK: int = 0
+    UNIT: str = ""
 
     def __init__(self, vif: VIF) -> None:
-        self._validate_vif(vif)
-        self._vif = vif
+        self._validate_vif_range(vif)
+        self._range: int = vif & self.RMASK
+        self._coef: int | float = 1
+        self._unit: str = self.UNIT
 
-    def _validate_vif(self, vif: VIF) -> None:
-        code = int(vif) & (~self.RCMASK)
+    def _validate_vif_range(self, vif: VIF) -> None:
+        code = int(vif) & (~self.RMASK)
         if (code & 0x7F) != self.CMASK:
             cls_name = type(self).__name__
             msg = f"{vif} does not match {cls_name}"
             raise MBusValidationError(msg)
 
-
-class PhysicalUnitVIFCode(VIFCode):
-    def __init__(self, vif: VIF) -> None:
-        super().__init__(vif=vif)
-        self._power = vif & self.RCMASK
-        self._coef: int | float = 1
-
     @property
-    def multiplier(self) -> int | float:
+    def coef(self) -> int | float:
         """Return multiplier/coeffiecent value.
 
         By default, the value is 1.
         """
+
         return self._coef
 
+    @property
+    def range_code(self) -> int:
+        """Return range code value.
 
-class EnergyWattHourVIFCode(PhysicalUnitVIFCode):
+        Roughly equivalent to `vif & self.RMASK`.
+        For ranged codes, this value may determine
+        the value of the `coef` attribute.
+        """
+
+        return self._range
+
+    @property
+    def unit(self) -> str:
+        """Return unit of measurement.
+
+        By default, an empty string -> non measureable.
+        """
+
+        return self._unit
+
+
+class EnergyWattHourVIFCode(VIFCode):
     CMASK = 0b0000_0000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
+    UNIT = "Wh"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class EnergyJouleVIFCode(PhysicalUnitVIFCode):
+class EnergyJouleVIFCode(VIFCode):
     CMASK = 0b0000_1000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
+    UNIT = "J"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10**self._power
+        self._coef = 10**self.range_code
 
 
-class VolumeMeterCubicVIFCode(PhysicalUnitVIFCode):
+class VolumeMeterCubicVIFCode(VIFCode):
     CMASK = 0b0001_0000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
+    UNIT = "m^3"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 6)
+        self._coef = 10 ** (self.range_code - 6)
 
 
-class MassKilogramVIFCode(PhysicalUnitVIFCode):
+class MassKilogramVIFCode(VIFCode):
     CMASK = 0b0001_1000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
+    UNIT = "kg"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class TimePartVIFCode(PhysicalUnitVIFCode):
+class TimePartVIFCode(VIFCode):
     """Time part VIF code class.
 
     A helper class for subtyping time VIF codes.
     """
 
     # CMASK is defined in the subclasses
-    RCMASK = 0b0000_0011
+    RMASK = 0b0000_0011
+    UNIT = "time"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
+        match self.range_code:
+            case 3:
+                self._unit = "day"
+            case 2:
+                self._unit = "hour"
+            case 1:
+                self._unit = "minute"
+            case 0:
+                self._unit = "second"
 
     def is_day(self) -> bool:
         """Return True if Time is in days."""
-        return self._power == 3
+        return self.range_code == 3
 
     def is_hour(self) -> bool:
         """Return True if Time is in hours."""
-        return self._power == 2
+        return self.range_code == 2
 
     def is_minute(self) -> bool:
         """Return True if Time is in minutes."""
-        return self._power == 1
+        return self.range_code == 1
 
     def is_second(self) -> bool:
         """Return True if Time is in seconds."""
-        return not self._power
+        return not self.range_code
 
 
 class OnTimeVIFCode(TimePartVIFCode):
@@ -108,124 +152,129 @@ class OperatingTimeVIFCode(TimePartVIFCode):
     CMASK = 0b0010_0100
 
 
-class PowerWattVIFCode(PhysicalUnitVIFCode):
+class PowerWattVIFCode(VIFCode):
     CMASK = 0b0010_1000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
+    UNIT = "W"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class PowerJoulePerHourVIFCode(PhysicalUnitVIFCode):
+class PowerJoulePerHourVIFCode(VIFCode):
     CMASK = 0b0011_0000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
+    UNIT = "J/h"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10**self._power
+        self._coef = 10**self.range_code
 
 
-class VolumeFlowMeterCubicPerHourVIFCode(PhysicalUnitVIFCode):
+class VolumeFlowMeterCubicPerHourVIFCode(VIFCode):
     CMASK = 0b0011_1000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 6)
+        self._coef = 10 ** (self.range_code - 6)
 
 
-class VolumeFlowMeterCubicPerMinuteVIFCode(PhysicalUnitVIFCode):
+class VolumeFlowMeterCubicPerMinuteVIFCode(VIFCode):
     CMASK = 0b0100_0000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 7)
+        self._coef = 10 ** (self.range_code - 7)
 
 
-class VolumeFlowMeterCubicPerSecondVIFCode(PhysicalUnitVIFCode):
+class VolumeFlowMeterCubicPerSecondVIFCode(VIFCode):
     CMASK = 0b0100_1000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 9)
+        self._coef = 10 ** (self.range_code - 9)
 
 
-class MassFlowKilogramPerHourVIFCode(PhysicalUnitVIFCode):
+class MassFlowKilogramPerHourVIFCode(VIFCode):
     CMASK = 0b0101_0000
-    RCMASK = 0b0000_0111
+    RMASK = 0b0000_0111
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class TemperatureFlowCelsiusVIFCode(PhysicalUnitVIFCode):
+class TemperatureFlowCelsiusVIFCode(VIFCode):
     CMASK = 0b0101_1000
-    RCMASK = 0b0000_0011
+    RMASK = 0b0000_0011
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class TemperatureReturnCelsiusVIFCode(PhysicalUnitVIFCode):
+class TemperatureReturnCelsiusVIFCode(VIFCode):
     CMASK = 0b0101_1100
-    RCMASK = 0b0000_0011
+    RMASK = 0b0000_0011
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class TemperatureDifferenceKelvinVIFCode(PhysicalUnitVIFCode):
+class TemperatureDifferenceKelvinVIFCode(VIFCode):
     CMASK = 0b0110_0000
-    RCMASK = 0b0000_0011
+    RMASK = 0b0000_0011
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class TemperatureExternalCelsiusVIFCode(PhysicalUnitVIFCode):
+class TemperatureExternalCelsiusVIFCode(VIFCode):
     CMASK = 0b0110_0100
-    RCMASK = 0b0000_0011
+    RMASK = 0b0000_0011
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class PressureBarVIFCode(PhysicalUnitVIFCode):
+class PressureBarVIFCode(VIFCode):
     CMASK = 0b0110_1000
-    RCMASK = 0b0000_0011
+    RMASK = 0b0000_0011
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self._coef = 10 ** (self._power - 3)
+        self._coef = 10 ** (self.range_code - 3)
 
 
-class TimePointVIFCode(PhysicalUnitVIFCode):
+class TimePointVIFCode(VIFCode):
     CMASK = 0b0110_1100
-    RCMASK = 0b0000_0001
+    RMASK = 0b0000_0001
+    UNIT = "date | datetime"
 
     def __init__(self, vif: VIF) -> None:
         super().__init__(vif)
-        self.UNIT = "datetime" if self._power else "date"
+        self._unit = "datetime" if self.range_code else "date"
         self._coef = 1
 
     def is_date(self) -> bool:
         """Return True if TimePoint has the LSB=0."""
-        return not self._power
+
+        return not self.range_code
 
     def is_datetime(self) -> bool:
         """Return True if TimePoint has the LSB=1."""
-        return bool(self._power)
+
+        return bool(self.range_code)
 
 
-class HeatCostAllocatorUnitsVIFCode(PhysicalUnitVIFCode):
+class HeatCostAllocatorUnitsVIFCode(VIFCode):
     CMASK = 0b0110_1110
 
 
@@ -253,67 +302,191 @@ class BusAddressVIFCode(VIFCode):
     CMASK = 0b0111_1010
 
 
+class UserDefinedVIFCode(VIFCode):
+    CMASK = 0b0111_1100
+
+
+class AnyVIFCode(VIFCode):
+    CMASK = 0b0111_1110
+
+
+class ManufacturerSpecificVIFCode(VIFCode):
+    CMASK = 0b0111_1111
+
+
+_VIF_CODE_MAP: dict[int, type[VIFCode]] = {
+    # E000_0nnn
+    0b0000_0000: EnergyWattHourVIFCode,
+    0b0000_0001: EnergyWattHourVIFCode,
+    0b0000_0010: EnergyWattHourVIFCode,
+    0b0000_0011: EnergyWattHourVIFCode,
+    0b0000_0100: EnergyWattHourVIFCode,
+    0b0000_0101: EnergyWattHourVIFCode,
+    0b0000_0110: EnergyWattHourVIFCode,
+    0b0000_0111: EnergyWattHourVIFCode,
+    # E000_1nnn
+    0b0000_1000: EnergyJouleVIFCode,
+    0b0000_1001: EnergyJouleVIFCode,
+    0b0000_1010: EnergyJouleVIFCode,
+    0b0000_1011: EnergyJouleVIFCode,
+    0b0000_1100: EnergyJouleVIFCode,
+    0b0000_1101: EnergyJouleVIFCode,
+    0b0000_1110: EnergyJouleVIFCode,
+    0b0000_1111: EnergyJouleVIFCode,
+    # E001_0nnn
+    0b0001_0000: VolumeMeterCubicVIFCode,
+    0b0001_0001: VolumeMeterCubicVIFCode,
+    0b0001_0010: VolumeMeterCubicVIFCode,
+    0b0001_0011: VolumeMeterCubicVIFCode,
+    0b0001_0100: VolumeMeterCubicVIFCode,
+    0b0001_0101: VolumeMeterCubicVIFCode,
+    0b0001_0110: VolumeMeterCubicVIFCode,
+    0b0001_0111: VolumeMeterCubicVIFCode,
+    # E001_1nnn
+    0b0001_1000: MassKilogramVIFCode,
+    0b0001_1001: MassKilogramVIFCode,
+    0b0001_1010: MassKilogramVIFCode,
+    0b0001_1011: MassKilogramVIFCode,
+    0b0001_1100: MassKilogramVIFCode,
+    0b0001_1101: MassKilogramVIFCode,
+    0b0001_1110: MassKilogramVIFCode,
+    0b0001_1111: MassKilogramVIFCode,
+    # E010_00nn
+    0b0010_0000: OnTimeVIFCode,
+    0b0010_0001: OnTimeVIFCode,
+    0b0010_0010: OnTimeVIFCode,
+    0b0010_0011: OnTimeVIFCode,
+    # E010_01nn
+    0b0010_0100: OperatingTimeVIFCode,
+    0b0010_0101: OperatingTimeVIFCode,
+    0b0010_0110: OperatingTimeVIFCode,
+    0b0010_0111: OperatingTimeVIFCode,
+    # E010_1nnn
+    0b0010_1000: PowerWattVIFCode,
+    0b0010_1001: PowerWattVIFCode,
+    0b0010_1010: PowerWattVIFCode,
+    0b0010_1011: PowerWattVIFCode,
+    0b0010_1100: PowerWattVIFCode,
+    0b0010_1101: PowerWattVIFCode,
+    0b0010_1110: PowerWattVIFCode,
+    0b0010_1111: PowerWattVIFCode,
+    # E011_0nnn
+    0b0011_0000: PowerJoulePerHourVIFCode,
+    0b0011_0001: PowerJoulePerHourVIFCode,
+    0b0011_0010: PowerJoulePerHourVIFCode,
+    0b0011_0011: PowerJoulePerHourVIFCode,
+    0b0011_0100: PowerJoulePerHourVIFCode,
+    0b0011_0101: PowerJoulePerHourVIFCode,
+    0b0011_0110: PowerJoulePerHourVIFCode,
+    0b0011_0111: PowerJoulePerHourVIFCode,
+    # E011_1nnn
+    0b0011_1000: VolumeFlowMeterCubicPerHourVIFCode,
+    0b0011_1001: VolumeFlowMeterCubicPerHourVIFCode,
+    0b0011_1010: VolumeFlowMeterCubicPerHourVIFCode,
+    0b0011_1011: VolumeFlowMeterCubicPerHourVIFCode,
+    0b0011_1100: VolumeFlowMeterCubicPerHourVIFCode,
+    0b0011_1101: VolumeFlowMeterCubicPerHourVIFCode,
+    0b0011_1110: VolumeFlowMeterCubicPerHourVIFCode,
+    0b0011_1111: VolumeFlowMeterCubicPerHourVIFCode,
+    # E100_0nnn
+    0b0100_0000: VolumeFlowMeterCubicPerMinuteVIFCode,
+    0b0100_0001: VolumeFlowMeterCubicPerMinuteVIFCode,
+    0b0100_0010: VolumeFlowMeterCubicPerMinuteVIFCode,
+    0b0100_0011: VolumeFlowMeterCubicPerMinuteVIFCode,
+    0b0100_0100: VolumeFlowMeterCubicPerMinuteVIFCode,
+    0b0100_0101: VolumeFlowMeterCubicPerMinuteVIFCode,
+    0b0100_0110: VolumeFlowMeterCubicPerMinuteVIFCode,
+    0b0100_0111: VolumeFlowMeterCubicPerMinuteVIFCode,
+    # E100_1nnn
+    0b0100_1000: VolumeFlowMeterCubicPerSecondVIFCode,
+    0b0100_1001: VolumeFlowMeterCubicPerSecondVIFCode,
+    0b0100_1010: VolumeFlowMeterCubicPerSecondVIFCode,
+    0b0100_1011: VolumeFlowMeterCubicPerSecondVIFCode,
+    0b0100_1100: VolumeFlowMeterCubicPerSecondVIFCode,
+    0b0100_1101: VolumeFlowMeterCubicPerSecondVIFCode,
+    0b0100_1110: VolumeFlowMeterCubicPerSecondVIFCode,
+    0b0100_1111: VolumeFlowMeterCubicPerSecondVIFCode,
+    # E101_0nnn
+    0b0101_0000: MassFlowKilogramPerHourVIFCode,
+    0b0101_0001: MassFlowKilogramPerHourVIFCode,
+    0b0101_0010: MassFlowKilogramPerHourVIFCode,
+    0b0101_0011: MassFlowKilogramPerHourVIFCode,
+    0b0101_0100: MassFlowKilogramPerHourVIFCode,
+    0b0101_0101: MassFlowKilogramPerHourVIFCode,
+    0b0101_0110: MassFlowKilogramPerHourVIFCode,
+    0b0101_0111: MassFlowKilogramPerHourVIFCode,
+    # E101_10nn
+    0b0101_1000: TemperatureFlowCelsiusVIFCode,
+    0b0101_1001: TemperatureFlowCelsiusVIFCode,
+    0b0101_1010: TemperatureFlowCelsiusVIFCode,
+    0b0101_1011: TemperatureFlowCelsiusVIFCode,
+    # E101_11nn
+    0b0101_1100: TemperatureReturnCelsiusVIFCode,
+    0b0101_1101: TemperatureReturnCelsiusVIFCode,
+    0b0101_1110: TemperatureReturnCelsiusVIFCode,
+    0b0101_1111: TemperatureReturnCelsiusVIFCode,
+    # E110_00nn
+    0b0110_0000: TemperatureDifferenceKelvinVIFCode,
+    0b0110_0001: TemperatureDifferenceKelvinVIFCode,
+    0b0110_0010: TemperatureDifferenceKelvinVIFCode,
+    0b0110_0011: TemperatureDifferenceKelvinVIFCode,
+    # E110_01nn
+    0b0110_0100: TemperatureExternalCelsiusVIFCode,
+    0b0110_0101: TemperatureExternalCelsiusVIFCode,
+    0b0110_0110: TemperatureExternalCelsiusVIFCode,
+    0b0110_0111: TemperatureExternalCelsiusVIFCode,
+    # E110_10nn
+    0b0110_1000: PressureBarVIFCode,
+    0b0110_1001: PressureBarVIFCode,
+    0b0110_1010: PressureBarVIFCode,
+    0b0110_1011: PressureBarVIFCode,
+    # E110_110n
+    0b0110_1100: TimePointVIFCode,
+    0b0110_1101: TimePointVIFCode,
+    # E110_1110
+    0b0110_1110: HeatCostAllocatorUnitsVIFCode,
+    # E110_1111 -> reserved
+    0b0110_1111: ReservedVIFCode,
+    # E111_00nn
+    0b0111_0000: DurationAveragingVIFCode,
+    0b0111_0001: DurationAveragingVIFCode,
+    0b0111_0010: DurationAveragingVIFCode,
+    0b0111_0011: DurationAveragingVIFCode,
+    # E111_01nn
+    0b0111_0100: DurationActualityVIFCode,
+    0b0111_0101: DurationActualityVIFCode,
+    0b0111_0110: DurationActualityVIFCode,
+    0b0111_0111: DurationActualityVIFCode,
+    # E111_1000
+    0b0111_1000: FabricationNoVIFCode,
+    # E111_1001
+    0b0111_1001: EnhancedIdentificationVIFCode,
+    # E111_1010
+    0b0111_1010: BusAddressVIFCode,
+    # special purpose VIF codes
+    0b0111_1100: UserDefinedVIFCode,
+    0b0111_1110: AnyVIFCode,
+    0b0111_1111: ManufacturerSpecificVIFCode,
+}
+
+
 def get_vif_code(byte: int | VIF) -> None | VIFCode:  # noqa: C901
     """Return the VIFCode according to the given VIF.
 
     Parameters
     ----------
-    vif : int | VIF
+    byte : int | VIF
+        either an integer or VIF class
 
     Returns
     -------
-    None | ValueInformationFieldCode
+    None | VIFCode
     """
 
-    vif = VIF(int(byte))
-    if vif < 0x08:  # Energy (Wh) -> E000_0nnn
-        return EnergyWattHourVIFCode(vif)
-    if vif < 0x10:  # Energy (J) -> E000_1nnn
-        return EnergyJouleVIFCode(vif)
-    if vif < 0x18:  # Volume (m^3) -> E001_0nnn
-        return VolumeMeterCubicVIFCode(vif)
-    if vif < 0x20:  # Mass (kg) -> E001_1nnn
-        return MassKilogramVIFCode(vif)
-    if vif < 0x24:  # On Time -> E010_00nn
-        return OnTimeVIFCode(vif)
-    if vif < 0x28:  # Operating Time (like OnTime) -> E010_01nn
-        return OperatingTimeVIFCode(vif)
-    if vif < 0x30:  # Power (W) -> E010_1nnn
-        return PowerWattVIFCode(vif)
-    if vif < 0x38:  # Power (J/h) -> E011_0nnn
-        return PowerJoulePerHourVIFCode(vif)
-    if vif < 0x40:  # Volume flow (m^3/h) -> E011_1nnn
-        return VolumeFlowMeterCubicPerHourVIFCode(vif)
-    if vif < 0x48:  # Volume flow ext. (m^3/min) -> E100_0nnn
-        return VolumeFlowMeterCubicPerMinuteVIFCode(vif)
-    if vif < 0x50:  # Volume flow (m^3/s) -> E100_1nnn
-        return VolumeFlowMeterCubicPerSecondVIFCode(vif)
-    if vif < 0x58:  # Mass flow (kg/h) -> E101_0nnn
-        return MassFlowKilogramPerHourVIFCode(vif)
-    if vif < 0x5C:  # Flow temperature (C) -> E101_10nn
-        return TemperatureFlowCelsiusVIFCode(vif)
-    if vif < 0x60:  # Return temperature (C) -> E101_11nn
-        return TemperatureReturnCelsiusVIFCode(vif)
-    if vif < 0x64:  # Temperature difference (K) -> E110_00nn
-        return TemperatureDifferenceKelvinVIFCode(vif)
-    if vif < 0x68:  # Temperature difference (C) -> E110_01nn
-        return TemperatureExternalCelsiusVIFCode(vif)
-    if vif < 0x6C:  # Pressure (bar) -> E110_10nn
-        return PressureBarVIFCode(vif)
-    if vif < 0x6E:  # Time point (date or datetime) -> E110_110n
-        return TimePointVIFCode(vif)
-    if vif == 0x6E:
-        return HeatCostAllocatorUnitsVIFCode(vif)
-    if vif == 0x6F:
-        return ReservedVIFCode(vif)
-    if vif < 0x74:  # Averaging duration (like OnTime) -> E111_00nn
-        return DurationAveragingVIFCode(vif)
-    if vif < 0x78:  # Actuality duration (like OnTime) -> E111_01nn
-        return DurationActualityVIFCode(vif)
-    if vif == 0x78:
-        return FabricationNoVIFCode(vif)
-    if vif == 0x79:
-        return EnhancedIdentificationVIFCode(vif)
-    if vif == 0x7A:
-        return BusAddressVIFCode(vif)
+    byte = int(byte)  # ensure int
+    vif = VIF(byte)  # validate byte range
+
+    vif_code_type = _VIF_CODE_MAP.get(byte)
+    if vif_code_type is not None:
+        return vif_code_type(vif)
     return None

--- a/tests/codes/test_vif_codes.py
+++ b/tests/codes/test_vif_codes.py
@@ -1,72 +1,13 @@
-from typing import cast
-
 import pytest
 
 from pymbus.codes.vif import (
-    AnyVIFCode,
-    BusAddressVIFCode,
-    DurationActualityVIFCode,
-    DurationAveragingVIFCode,
-    EnergyJouleVIFCode,
-    EnergyWattHourVIFCode,
-    EnhancedIdentificationVIFCode,
-    FabricationNoVIFCode,
-    HeatCostAllocatorUnitsVIFCode,
-    ManufacturerSpecificVIFCode,
-    MassFlowKilogramPerHourVIFCode,
-    MassKilogramVIFCode,
-    OnTimeVIFCode,
-    OperatingTimeVIFCode,
-    PowerJoulePerHourVIFCode,
-    PowerWattVIFCode,
-    PressureBarVIFCode,
-    ReservedVIFCode,
-    TemperatureDifferenceKelvinVIFCode,
-    TemperatureExternalCelsiusVIFCode,
-    TemperatureFlowCelsiusVIFCode,
-    TemperatureReturnCelsiusVIFCode,
-    TimePartVIFCode,
-    TimePointVIFCode,
-    UserDefinedVIFCode,
-    VolumeFlowMeterCubicPerHourVIFCode,
-    VolumeFlowMeterCubicPerMinuteVIFCode,
-    VolumeFlowMeterCubicPerSecondVIFCode,
-    VolumeMeterCubicVIFCode,
+    VIFCode,
+    VIFCodeDescription,
+    VIFCodeUnit,
     get_vif_code,
-)
-from pymbus.codes.vif import (
-    VIFCode as VIFC,
 )
 from pymbus.exceptions import MBusValidationError
 from pymbus.telegrams.fields import ValueInformationField as VIF
-
-
-def _assert_vif_code(
-    vif: VIF, code_type: type[VIFC], *, coef: float = 1
-) -> VIFC:
-    code = get_vif_code(vif)
-    if code is None:
-        msg = f"no match for {vif}"
-        raise ValueError(msg)
-    assert isinstance(code, code_type)
-
-    assert code.coef == coef
-    return code
-
-
-def _assert_time_vif_code(
-    vif: VIF, vif_code: TimePartVIFCode
-) -> TimePartVIFCode:
-    match vif & 0x03:
-        case 0:
-            assert vif_code.is_second()
-        case 1:
-            assert vif_code.is_minute()
-        case 2:
-            assert vif_code.is_hour()
-        case 3:
-            assert vif_code.is_day()
-    return vif_code
 
 
 def test_bad_nonbyte_value():
@@ -79,314 +20,630 @@ def test_no_vif_code():
 
 
 @pytest.mark.parametrize(
-    ("vif", "coef"),
+    ("vif", "coef", "desc", "unit"),
     [
-        (VIF(0b0000_0000), 1e-3),
-        (VIF(0b0000_0001), 1e-2),
-        (VIF(0b0000_0010), 1e-1),
-        (VIF(0b0000_0011), 1e-0),
-        (VIF(0b0000_0100), 1e1),
-        (VIF(0b0000_0101), 1e2),
-        (VIF(0b0000_0110), 1e3),
-        (VIF(0b0000_0111), 1e4),
+        # Energy (Watt * hour)
+        (
+            VIF(0b0000_0000),
+            1e-3,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0001),
+            1e-2,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0010),
+            1e-1,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0011),
+            1e0,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0100),
+            1e1,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0101),
+            1e2,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0110),
+            1e3,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0111),
+            1e4,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        # Energy (Joule)
+        (VIF(0b0000_1000), 1e0, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1001), 1e1, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1010), 1e2, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1011), 1e3, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1100), 1e4, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1101), 1e5, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1110), 1e6, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1111), 1e7, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        # Volume (Meter cubic)
+        (
+            VIF(0b0001_0000),
+            1e-6,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0001),
+            1e-5,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0010),
+            1e-4,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0011),
+            1e-3,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0100),
+            1e-2,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0101),
+            1e-1,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0110),
+            1e0,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0111),
+            1e1,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        # Mass (Kilogram)
+        (VIF(0b0001_1000), 1e-3, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1001), 1e-2, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1010), 1e-1, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1011), 1e0, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1100), 1e1, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1101), 1e2, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1110), 1e3, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1111), 1e4, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        # On Time (time parts -> days, hours, minutes, seconds)
+        (VIF(0b0010_0000), 1, VIFCodeDescription.on_time, VIFCodeUnit.second),
+        (VIF(0b0010_0001), 60, VIFCodeDescription.on_time, VIFCodeUnit.second),
+        (
+            VIF(0b0010_0010),
+            3600,
+            VIFCodeDescription.on_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0011),
+            86400,
+            VIFCodeDescription.on_time,
+            VIFCodeUnit.second,
+        ),
+        # Operating Time (like On Time)
+        (
+            VIF(0b0010_0100),
+            1,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0101),
+            60,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0110),
+            3600,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0111),
+            86400,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        # Power (Watt)
+        (VIF(0b0010_1000), 1e-3, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1001), 1e-2, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1010), 1e-1, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1011), 1e0, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1100), 1e1, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1101), 1e2, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1110), 1e3, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1111), 1e4, VIFCodeDescription.power, VIFCodeUnit.watt),
+        # Power (Joule/hour)
+        (
+            VIF(0b0011_0000),
+            1e0,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0001),
+            1e1,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0010),
+            1e2,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0011),
+            1e3,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0100),
+            1e4,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0101),
+            1e5,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0110),
+            1e6,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0111),
+            1e7,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        # Volume flow (m^3/hour)
+        (
+            VIF(0b0011_1000),
+            1e-6,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1001),
+            1e-5,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1010),
+            1e-4,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1011),
+            1e-3,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1100),
+            1e-2,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1101),
+            1e-1,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1110),
+            1e0,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1111),
+            1e1,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        # Volume flow (m^3/min)
+        (
+            VIF(0b0100_0000),
+            1e-7,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0001),
+            1e-6,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0010),
+            1e-5,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0011),
+            1e-4,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0100),
+            1e-3,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0101),
+            1e-2,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0110),
+            1e-1,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0111),
+            1e0,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        # Volume flow (m^3/min)
+        (
+            VIF(0b0100_1000),
+            1e-9,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1001),
+            1e-8,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1010),
+            1e-7,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1011),
+            1e-6,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1100),
+            1e-5,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1101),
+            1e-4,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1110),
+            1e-3,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1111),
+            1e-2,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        # Mass flow (kg/h)
+        (
+            VIF(0b0101_0000),
+            1e-3,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0001),
+            1e-2,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0010),
+            1e-1,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0011),
+            1e0,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0100),
+            1e1,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0101),
+            1e2,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0110),
+            1e3,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0111),
+            1e4,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        # Flow Temperature (C)
+        (
+            VIF(0b0101_1000),
+            1e-3,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1001),
+            1e-2,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1010),
+            1e-1,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1011),
+            1e0,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        # Return Temperature (C)
+        (
+            VIF(0b0101_1100),
+            1e-3,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1101),
+            1e-2,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1110),
+            1e-1,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1111),
+            1e0,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        # Temperature Difference (K)
+        (
+            VIF(0b0110_0000),
+            1e-3,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        (
+            VIF(0b0110_0001),
+            1e-2,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        (
+            VIF(0b0110_0010),
+            1e-1,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        (
+            VIF(0b0110_0011),
+            1e-0,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        # External Temperature (C)
+        (
+            VIF(0b0110_0100),
+            1e-3,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0110_0101),
+            1e-2,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0110_0110),
+            1e-1,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0110_0111),
+            1e-0,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        # Pressure (bar)
+        (VIF(0b0110_1000), 1e-3, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        (VIF(0b0110_1001), 1e-2, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        (VIF(0b0110_1010), 1e-1, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        (VIF(0b0110_1011), 1e0, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        # TIme Point
+        (VIF(0b0110_1100), 1, VIFCodeDescription.time_point, VIFCodeUnit.date),
+        (
+            VIF(0b0110_1101),
+            1,
+            VIFCodeDescription.time_point,
+            VIFCodeUnit.datetime,
+        ),
+        # H.C.A. = Heat Cost Allocator
+        (VIF(0b0110_1110), 1, VIFCodeDescription.hca, VIFCodeUnit.hca),
+        # Reserved
+        (VIF(0b0110_1111), 1, VIFCodeDescription.reserved, VIFCodeUnit.unknown),
+        # Averaging duration (in seconds)
+        (
+            VIF(0b0111_0000),
+            1,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0001),
+            60,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0010),
+            3600,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0011),
+            86400,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        # Actuality duration (in seconds)
+        (
+            VIF(0b0111_0100),
+            1,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0101),
+            60,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0110),
+            3600,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0111),
+            86400,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        # Fabrication No
+        (
+            VIF(0b0111_1000),
+            1,
+            VIFCodeDescription.fabrication_no,
+            VIFCodeUnit.unknown,
+        ),
+        # Enhanced
+        (VIF(0b0111_1001), 1, VIFCodeDescription.enhanced, VIFCodeUnit.unknown),
+        # Bus address
+        (
+            VIF(0b0111_1010),
+            1,
+            VIFCodeDescription.bus_address,
+            VIFCodeUnit.unknown,
+        ),
+        # special purpose
+        (VIF(0b0111_1100), 1, VIFCodeDescription.user, VIFCodeUnit.unknown),
+        (VIF(0b0111_1110), 1, VIFCodeDescription.any, VIFCodeUnit.unknown),
+        (
+            VIF(0b0111_1111),
+            1,
+            VIFCodeDescription.manufacturer,
+            VIFCodeUnit.unknown,
+        ),
+        (
+            VIF(0b1111_1011),
+            1,
+            VIFCodeDescription.extension,
+            VIFCodeUnit.unknown,
+        ),
+        (
+            VIF(0b1111_1101),
+            1,
+            VIFCodeDescription.extension,
+            VIFCodeUnit.unknown,
+        ),
     ],
 )
-def test_energy_watt_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, EnergyWattHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0000_1000), 1e0),
-        (VIF(0b0000_1001), 1e1),
-        (VIF(0b0000_1010), 1e2),
-        (VIF(0b0000_1011), 1e3),
-        (VIF(0b0000_1100), 1e4),
-        (VIF(0b0000_1101), 1e5),
-        (VIF(0b0000_1110), 1e6),
-        (VIF(0b0000_1111), 1e7),
-    ],
-)
-def test_energy_joule_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, EnergyJouleVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0001_0000), 1e-6),
-        (VIF(0b0001_0001), 1e-5),
-        (VIF(0b0001_0010), 1e-4),
-        (VIF(0b0001_0011), 1e-3),
-        (VIF(0b0001_0100), 1e-2),
-        (VIF(0b0001_0101), 1e-1),
-        (VIF(0b0001_0110), 1e0),
-        (VIF(0b0001_0111), 1e1),
-    ],
-)
-def test_volume_meter_cubic_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeMeterCubicVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0001_1000), 1e-3),
-        (VIF(0b0001_1001), 1e-2),
-        (VIF(0b0001_1010), 1e-1),
-        (VIF(0b0001_1011), 1e0),
-        (VIF(0b0001_1100), 1e1),
-        (VIF(0b0001_1101), 1e2),
-        (VIF(0b0001_1110), 1e3),
-        (VIF(0b0001_1111), 1e4),
-    ],
-)
-def test_mass_kilogram_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, MassKilogramVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0010_0000), VIF(0b0010_0001), VIF(0b0010_0010), VIF(0b0010_0011)],
-)
-def test_on_time_vif_codes(vif: VIF):
-    tcode = cast(
-        "TimePartVIFCode", _assert_vif_code(vif, OnTimeVIFCode, coef=1)
+def test_vif_codes(
+    vif: VIF, coef: float, desc: VIFCodeDescription, unit: VIFCodeUnit
+):
+    assert get_vif_code(vif) == VIFCode(
+        code=int(vif),
+        coef=coef,
+        desc=desc,
+        unit=unit,
     )
-    _assert_time_vif_code(vif, tcode)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0010_0100), VIF(0b0010_0101), VIF(0b0010_0110), VIF(0b0010_0111)],
-)
-def test_operating_time_vif_codes(vif: VIF):
-    tcode = cast(
-        "TimePartVIFCode", _assert_vif_code(vif, OperatingTimeVIFCode, coef=1)
-    )
-    _assert_time_vif_code(vif, tcode)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0010_1000), 1e-3),
-        (VIF(0b0010_1001), 1e-2),
-        (VIF(0b0010_1010), 1e-1),
-        (VIF(0b0010_1011), 1e0),
-        (VIF(0b0010_1100), 1e1),
-        (VIF(0b0010_1101), 1e2),
-        (VIF(0b0010_1110), 1e3),
-        (VIF(0b0010_1111), 1e4),
-    ],
-)
-def test_power_watt_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, PowerWattVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0011_0000), 1e0),
-        (VIF(0b0011_0001), 1e1),
-        (VIF(0b0011_0010), 1e2),
-        (VIF(0b0011_0011), 1e3),
-        (VIF(0b0011_0100), 1e4),
-        (VIF(0b0011_0101), 1e5),
-        (VIF(0b0011_0110), 1e6),
-        (VIF(0b0011_0111), 1e7),
-    ],
-)
-def test_power_joule_per_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, PowerJoulePerHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0011_1000), 1e-6),
-        (VIF(0b0011_1001), 1e-5),
-        (VIF(0b0011_1010), 1e-4),
-        (VIF(0b0011_1011), 1e-3),
-        (VIF(0b0011_1100), 1e-2),
-        (VIF(0b0011_1101), 1e-1),
-        (VIF(0b0011_1110), 1e0),
-        (VIF(0b0011_1111), 1e1),
-    ],
-)
-def test_volume_flow_meter_cubic_per_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeFlowMeterCubicPerHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0100_0000), 1e-7),
-        (VIF(0b0100_0001), 1e-6),
-        (VIF(0b0100_0010), 1e-5),
-        (VIF(0b0100_0011), 1e-4),
-        (VIF(0b0100_0100), 1e-3),
-        (VIF(0b0100_0101), 1e-2),
-        (VIF(0b0100_0110), 1e-1),
-        (VIF(0b0100_0111), 1e0),
-    ],
-)
-def test_volume_flow_meter_cubic_per_minute_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeFlowMeterCubicPerMinuteVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0100_1000), 1e-9),
-        (VIF(0b0100_1001), 1e-8),
-        (VIF(0b0100_1010), 1e-7),
-        (VIF(0b0100_1011), 1e-6),
-        (VIF(0b0100_1100), 1e-5),
-        (VIF(0b0100_1101), 1e-4),
-        (VIF(0b0100_1110), 1e-3),
-        (VIF(0b0100_1111), 1e-2),
-    ],
-)
-def test_volume_flow_meter_cubic_per_second_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeFlowMeterCubicPerSecondVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0101_0000), 1e-3),
-        (VIF(0b0101_0001), 1e-2),
-        (VIF(0b0101_0010), 1e-1),
-        (VIF(0b0101_0011), 1e0),
-        (VIF(0b0101_0100), 1e1),
-        (VIF(0b0101_0101), 1e2),
-        (VIF(0b0101_0110), 1e3),
-        (VIF(0b0101_0111), 1e4),
-    ],
-)
-def test_mass_flow_kilogram_per_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, MassFlowKilogramPerHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0101_1000), 1e-3),
-        (VIF(0b0101_1001), 1e-2),
-        (VIF(0b0101_1010), 1e-1),
-        (VIF(0b0101_1011), 1e0),
-    ],
-)
-def test_temperature_flow_celsius_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureFlowCelsiusVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0101_1100), 1e-3),
-        (VIF(0b0101_1101), 1e-2),
-        (VIF(0b0101_1110), 1e-1),
-        (VIF(0b0101_1111), 1e0),
-    ],
-)
-def test_temperature_return_celsius_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureReturnCelsiusVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0110_0000), 1e-3),
-        (VIF(0b0110_0001), 1e-2),
-        (VIF(0b0110_0010), 1e-1),
-        (VIF(0b0110_0011), 1e-0),
-    ],
-)
-def test_temperature_difference_kelvin_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureDifferenceKelvinVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0110_0100), 1e-3),
-        (VIF(0b0110_0101), 1e-2),
-        (VIF(0b0110_0110), 1e-1),
-        (VIF(0b0110_0111), 1e-0),
-    ],
-)
-def test_temperature_external_celsius_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureExternalCelsiusVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0110_1000), 1e-3),
-        (VIF(0b0110_1001), 1e-2),
-        (VIF(0b0110_1010), 1e-1),
-        (VIF(0b0110_1011), 1e0),
-    ],
-)
-def test_pressure_bar_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, PressureBarVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0110_1100), VIF(0b0110_1101)],
-)
-def test_time_point_vif_codes(vif: VIF):
-    code = cast(
-        "TimePointVIFCode", _assert_vif_code(vif, TimePointVIFCode, coef=1)
-    )
-    match vif & 0x01:
-        case 0:
-            assert code.is_date()
-        case 1:
-            assert code.is_datetime()
-
-
-def test_hca_units_vif_code():
-    _assert_vif_code(VIF(0b0110_1110), HeatCostAllocatorUnitsVIFCode, coef=1)
-
-
-def test_reserved_e110_1111_vif_code():
-    _assert_vif_code(VIF(0b0110_1111), ReservedVIFCode, coef=1)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0111_0000), VIF(0b0111_0001), VIF(0b0111_0010), VIF(0b0111_0011)],
-)
-def test_averaging_duration_vif_codes(vif: VIF):
-    _assert_vif_code(vif, DurationAveragingVIFCode, coef=1)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0111_0100), VIF(0b0111_0101), VIF(0b0111_0110), VIF(0b0111_0111)],
-)
-def test_actuality_duration_vif_codes(vif: VIF):
-    _assert_vif_code(vif, DurationActualityVIFCode, coef=1)
-
-
-def test_fabriaction_no_vif_code():
-    _assert_vif_code(VIF(0b0111_1000), FabricationNoVIFCode, coef=1)
-
-
-def test_enhanced_identification_vif_code():
-    _assert_vif_code(VIF(0b0111_1001), EnhancedIdentificationVIFCode, coef=1)
-
-
-def test_bus_address_vif_code():
-    _assert_vif_code(VIF(0b0111_1010), BusAddressVIFCode, coef=1)
-
-
-def test_special_purpose_vif_codes():
-    _assert_vif_code(VIF(0b0111_1100), UserDefinedVIFCode, coef=1)
-    _assert_vif_code(VIF(0b0111_1110), AnyVIFCode, coef=1)
-    _assert_vif_code(VIF(0b0111_1111), ManufacturerSpecificVIFCode, coef=1)


### PR DESCRIPTION
I am still unsure about the this way to process and convey VIF codes. For now it is so, but I am sure that only one VIFCode class must be (perhaps a dataclass) for not having lots of classes with duplicating information.

It is good to use a dictionary under the hood for the `get_vif_code` factory method.

UPD: fully adopts the changes from the #18 .