### PR TITLE
Make VIF codes dataclasses.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,9 +165,11 @@ fixable = ["I", "ICN", "ISC"]
 "{src,tests}/*.py" = [
     "N817",  # https://docs.astral.sh/ruff/rules/camelcase-imported-as-acronym/
 ]
+"src/pymbus/codes/vif.py" = ["ERA001"]
 "tests/*.py" = [
     "ANN201",  # https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/
     "D",
+    "ERA",
     "FBT001",  # https://docs.astral.sh/ruff/rules/boolean-type-hint-positional-argument/
     "PT011",  # https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
     "S",

--- a/tests/codes/test_vif_codes.py
+++ b/tests/codes/test_vif_codes.py
@@ -1,72 +1,13 @@
-from typing import cast
-
 import pytest
 
 from pymbus.codes.vif import (
-    AnyVIFCode,
-    BusAddressVIFCode,
-    DurationActualityVIFCode,
-    DurationAveragingVIFCode,
-    EnergyJouleVIFCode,
-    EnergyWattHourVIFCode,
-    EnhancedIdentificationVIFCode,
-    FabricationNoVIFCode,
-    HeatCostAllocatorUnitsVIFCode,
-    ManufacturerSpecificVIFCode,
-    MassFlowKilogramPerHourVIFCode,
-    MassKilogramVIFCode,
-    OnTimeVIFCode,
-    OperatingTimeVIFCode,
-    PowerJoulePerHourVIFCode,
-    PowerWattVIFCode,
-    PressureBarVIFCode,
-    ReservedVIFCode,
-    TemperatureDifferenceKelvinVIFCode,
-    TemperatureExternalCelsiusVIFCode,
-    TemperatureFlowCelsiusVIFCode,
-    TemperatureReturnCelsiusVIFCode,
-    TimePartVIFCode,
-    TimePointVIFCode,
-    UserDefinedVIFCode,
-    VolumeFlowMeterCubicPerHourVIFCode,
-    VolumeFlowMeterCubicPerMinuteVIFCode,
-    VolumeFlowMeterCubicPerSecondVIFCode,
-    VolumeMeterCubicVIFCode,
+    VIFCode,
+    VIFCodeDescription,
+    VIFCodeUnit,
     get_vif_code,
-)
-from pymbus.codes.vif import (
-    VIFCode as VIFC,
 )
 from pymbus.exceptions import MBusValidationError
 from pymbus.telegrams.fields import ValueInformationField as VIF
-
-
-def _assert_vif_code(
-    vif: VIF, code_type: type[VIFC], *, coef: float = 1
-) -> VIFC:
-    code = get_vif_code(vif)
-    if code is None:
-        msg = f"no match for {vif}"
-        raise ValueError(msg)
-    assert isinstance(code, code_type)
-
-    assert code.coef == coef
-    return code
-
-
-def _assert_time_vif_code(
-    vif: VIF, vif_code: TimePartVIFCode
-) -> TimePartVIFCode:
-    match vif & 0x03:
-        case 0:
-            assert vif_code.is_second()
-        case 1:
-            assert vif_code.is_minute()
-        case 2:
-            assert vif_code.is_hour()
-        case 3:
-            assert vif_code.is_day()
-    return vif_code
 
 
 def test_bad_nonbyte_value():
@@ -79,314 +20,630 @@ def test_no_vif_code():
 
 
 @pytest.mark.parametrize(
-    ("vif", "coef"),
+    ("vif", "coef", "desc", "unit"),
     [
-        (VIF(0b0000_0000), 1e-3),
-        (VIF(0b0000_0001), 1e-2),
-        (VIF(0b0000_0010), 1e-1),
-        (VIF(0b0000_0011), 1e-0),
-        (VIF(0b0000_0100), 1e1),
-        (VIF(0b0000_0101), 1e2),
-        (VIF(0b0000_0110), 1e3),
-        (VIF(0b0000_0111), 1e4),
+        # Energy (Watt * hour)
+        (
+            VIF(0b0000_0000),
+            1e-3,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0001),
+            1e-2,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0010),
+            1e-1,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0011),
+            1e0,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0100),
+            1e1,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0101),
+            1e2,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0110),
+            1e3,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        (
+            VIF(0b0000_0111),
+            1e4,
+            VIFCodeDescription.energy,
+            VIFCodeUnit.watt_hour,
+        ),
+        # Energy (Joule)
+        (VIF(0b0000_1000), 1e0, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1001), 1e1, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1010), 1e2, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1011), 1e3, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1100), 1e4, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1101), 1e5, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1110), 1e6, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        (VIF(0b0000_1111), 1e7, VIFCodeDescription.energy, VIFCodeUnit.joule),
+        # Volume (Meter cubic)
+        (
+            VIF(0b0001_0000),
+            1e-6,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0001),
+            1e-5,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0010),
+            1e-4,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0011),
+            1e-3,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0100),
+            1e-2,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0101),
+            1e-1,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0110),
+            1e0,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        (
+            VIF(0b0001_0111),
+            1e1,
+            VIFCodeDescription.volume,
+            VIFCodeUnit.meter_cubic,
+        ),
+        # Mass (Kilogram)
+        (VIF(0b0001_1000), 1e-3, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1001), 1e-2, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1010), 1e-1, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1011), 1e0, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1100), 1e1, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1101), 1e2, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1110), 1e3, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        (VIF(0b0001_1111), 1e4, VIFCodeDescription.mass, VIFCodeUnit.kilogram),
+        # On Time (time parts -> days, hours, minutes, seconds)
+        (VIF(0b0010_0000), 1, VIFCodeDescription.on_time, VIFCodeUnit.second),
+        (VIF(0b0010_0001), 60, VIFCodeDescription.on_time, VIFCodeUnit.second),
+        (
+            VIF(0b0010_0010),
+            3600,
+            VIFCodeDescription.on_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0011),
+            86400,
+            VIFCodeDescription.on_time,
+            VIFCodeUnit.second,
+        ),
+        # Operating Time (like On Time)
+        (
+            VIF(0b0010_0100),
+            1,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0101),
+            60,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0110),
+            3600,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0010_0111),
+            86400,
+            VIFCodeDescription.operating_time,
+            VIFCodeUnit.second,
+        ),
+        # Power (Watt)
+        (VIF(0b0010_1000), 1e-3, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1001), 1e-2, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1010), 1e-1, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1011), 1e0, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1100), 1e1, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1101), 1e2, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1110), 1e3, VIFCodeDescription.power, VIFCodeUnit.watt),
+        (VIF(0b0010_1111), 1e4, VIFCodeDescription.power, VIFCodeUnit.watt),
+        # Power (Joule/hour)
+        (
+            VIF(0b0011_0000),
+            1e0,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0001),
+            1e1,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0010),
+            1e2,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0011),
+            1e3,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0100),
+            1e4,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0101),
+            1e5,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0110),
+            1e6,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        (
+            VIF(0b0011_0111),
+            1e7,
+            VIFCodeDescription.power,
+            VIFCodeUnit.joule_per_hour,
+        ),
+        # Volume flow (m^3/hour)
+        (
+            VIF(0b0011_1000),
+            1e-6,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1001),
+            1e-5,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1010),
+            1e-4,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1011),
+            1e-3,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1100),
+            1e-2,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1101),
+            1e-1,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1110),
+            1e0,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        (
+            VIF(0b0011_1111),
+            1e1,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_hour,
+        ),
+        # Volume flow (m^3/min)
+        (
+            VIF(0b0100_0000),
+            1e-7,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0001),
+            1e-6,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0010),
+            1e-5,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0011),
+            1e-4,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0100),
+            1e-3,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0101),
+            1e-2,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0110),
+            1e-1,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        (
+            VIF(0b0100_0111),
+            1e0,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_minute,
+        ),
+        # Volume flow (m^3/min)
+        (
+            VIF(0b0100_1000),
+            1e-9,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1001),
+            1e-8,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1010),
+            1e-7,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1011),
+            1e-6,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1100),
+            1e-5,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1101),
+            1e-4,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1110),
+            1e-3,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        (
+            VIF(0b0100_1111),
+            1e-2,
+            VIFCodeDescription.volume_flow,
+            VIFCodeUnit.meter_cubic_per_second,
+        ),
+        # Mass flow (kg/h)
+        (
+            VIF(0b0101_0000),
+            1e-3,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0001),
+            1e-2,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0010),
+            1e-1,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0011),
+            1e0,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0100),
+            1e1,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0101),
+            1e2,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0110),
+            1e3,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        (
+            VIF(0b0101_0111),
+            1e4,
+            VIFCodeDescription.mass_flow,
+            VIFCodeUnit.kilogram_per_hour,
+        ),
+        # Flow Temperature (C)
+        (
+            VIF(0b0101_1000),
+            1e-3,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1001),
+            1e-2,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1010),
+            1e-1,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1011),
+            1e0,
+            VIFCodeDescription.flow_temp,
+            VIFCodeUnit.celsius,
+        ),
+        # Return Temperature (C)
+        (
+            VIF(0b0101_1100),
+            1e-3,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1101),
+            1e-2,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1110),
+            1e-1,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0101_1111),
+            1e0,
+            VIFCodeDescription.return_temp,
+            VIFCodeUnit.celsius,
+        ),
+        # Temperature Difference (K)
+        (
+            VIF(0b0110_0000),
+            1e-3,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        (
+            VIF(0b0110_0001),
+            1e-2,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        (
+            VIF(0b0110_0010),
+            1e-1,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        (
+            VIF(0b0110_0011),
+            1e-0,
+            VIFCodeDescription.temp_difference,
+            VIFCodeUnit.kelvin,
+        ),
+        # External Temperature (C)
+        (
+            VIF(0b0110_0100),
+            1e-3,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0110_0101),
+            1e-2,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0110_0110),
+            1e-1,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        (
+            VIF(0b0110_0111),
+            1e-0,
+            VIFCodeDescription.external_temp,
+            VIFCodeUnit.celsius,
+        ),
+        # Pressure (bar)
+        (VIF(0b0110_1000), 1e-3, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        (VIF(0b0110_1001), 1e-2, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        (VIF(0b0110_1010), 1e-1, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        (VIF(0b0110_1011), 1e0, VIFCodeDescription.pressure, VIFCodeUnit.bar),
+        # TIme Point
+        (VIF(0b0110_1100), 1, VIFCodeDescription.time_point, VIFCodeUnit.date),
+        (
+            VIF(0b0110_1101),
+            1,
+            VIFCodeDescription.time_point,
+            VIFCodeUnit.datetime,
+        ),
+        # H.C.A. = Heat Cost Allocator
+        (VIF(0b0110_1110), 1, VIFCodeDescription.hca, VIFCodeUnit.hca),
+        # Reserved
+        (VIF(0b0110_1111), 1, VIFCodeDescription.reserved, VIFCodeUnit.unknown),
+        # Averaging duration (in seconds)
+        (
+            VIF(0b0111_0000),
+            1,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0001),
+            60,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0010),
+            3600,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0011),
+            86400,
+            VIFCodeDescription.averaging_duration,
+            VIFCodeUnit.second,
+        ),
+        # Actuality duration (in seconds)
+        (
+            VIF(0b0111_0100),
+            1,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0101),
+            60,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0110),
+            3600,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        (
+            VIF(0b0111_0111),
+            86400,
+            VIFCodeDescription.actuality_duration,
+            VIFCodeUnit.second,
+        ),
+        # Fabrication No
+        (
+            VIF(0b0111_1000),
+            1,
+            VIFCodeDescription.fabrication_no,
+            VIFCodeUnit.unknown,
+        ),
+        # Enhanced
+        (VIF(0b0111_1001), 1, VIFCodeDescription.enhanced, VIFCodeUnit.unknown),
+        # Bus address
+        (
+            VIF(0b0111_1010),
+            1,
+            VIFCodeDescription.bus_address,
+            VIFCodeUnit.unknown,
+        ),
+        # special purpose
+        (VIF(0b0111_1100), 1, VIFCodeDescription.user, VIFCodeUnit.unknown),
+        (VIF(0b0111_1110), 1, VIFCodeDescription.any, VIFCodeUnit.unknown),
+        (
+            VIF(0b0111_1111),
+            1,
+            VIFCodeDescription.manufacturer,
+            VIFCodeUnit.unknown,
+        ),
+        (
+            VIF(0b1111_1011),
+            1,
+            VIFCodeDescription.extension,
+            VIFCodeUnit.unknown,
+        ),
+        (
+            VIF(0b1111_1101),
+            1,
+            VIFCodeDescription.extension,
+            VIFCodeUnit.unknown,
+        ),
     ],
 )
-def test_energy_watt_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, EnergyWattHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0000_1000), 1e0),
-        (VIF(0b0000_1001), 1e1),
-        (VIF(0b0000_1010), 1e2),
-        (VIF(0b0000_1011), 1e3),
-        (VIF(0b0000_1100), 1e4),
-        (VIF(0b0000_1101), 1e5),
-        (VIF(0b0000_1110), 1e6),
-        (VIF(0b0000_1111), 1e7),
-    ],
-)
-def test_energy_joule_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, EnergyJouleVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0001_0000), 1e-6),
-        (VIF(0b0001_0001), 1e-5),
-        (VIF(0b0001_0010), 1e-4),
-        (VIF(0b0001_0011), 1e-3),
-        (VIF(0b0001_0100), 1e-2),
-        (VIF(0b0001_0101), 1e-1),
-        (VIF(0b0001_0110), 1e0),
-        (VIF(0b0001_0111), 1e1),
-    ],
-)
-def test_volume_meter_cubic_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeMeterCubicVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0001_1000), 1e-3),
-        (VIF(0b0001_1001), 1e-2),
-        (VIF(0b0001_1010), 1e-1),
-        (VIF(0b0001_1011), 1e0),
-        (VIF(0b0001_1100), 1e1),
-        (VIF(0b0001_1101), 1e2),
-        (VIF(0b0001_1110), 1e3),
-        (VIF(0b0001_1111), 1e4),
-    ],
-)
-def test_mass_kilogram_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, MassKilogramVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0010_0000), VIF(0b0010_0001), VIF(0b0010_0010), VIF(0b0010_0011)],
-)
-def test_on_time_vif_codes(vif: VIF):
-    tcode = cast(
-        "TimePartVIFCode", _assert_vif_code(vif, OnTimeVIFCode, coef=1)
+def test_vif_codes(
+    vif: VIF, coef: float, desc: VIFCodeDescription, unit: VIFCodeUnit
+):
+    assert get_vif_code(vif) == VIFCode(
+        code=int(vif),
+        coef=coef,
+        desc=desc,
+        unit=unit,
     )
-    _assert_time_vif_code(vif, tcode)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0010_0100), VIF(0b0010_0101), VIF(0b0010_0110), VIF(0b0010_0111)],
-)
-def test_operating_time_vif_codes(vif: VIF):
-    tcode = cast(
-        "TimePartVIFCode", _assert_vif_code(vif, OperatingTimeVIFCode, coef=1)
-    )
-    _assert_time_vif_code(vif, tcode)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0010_1000), 1e-3),
-        (VIF(0b0010_1001), 1e-2),
-        (VIF(0b0010_1010), 1e-1),
-        (VIF(0b0010_1011), 1e0),
-        (VIF(0b0010_1100), 1e1),
-        (VIF(0b0010_1101), 1e2),
-        (VIF(0b0010_1110), 1e3),
-        (VIF(0b0010_1111), 1e4),
-    ],
-)
-def test_power_watt_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, PowerWattVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0011_0000), 1e0),
-        (VIF(0b0011_0001), 1e1),
-        (VIF(0b0011_0010), 1e2),
-        (VIF(0b0011_0011), 1e3),
-        (VIF(0b0011_0100), 1e4),
-        (VIF(0b0011_0101), 1e5),
-        (VIF(0b0011_0110), 1e6),
-        (VIF(0b0011_0111), 1e7),
-    ],
-)
-def test_power_joule_per_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, PowerJoulePerHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0011_1000), 1e-6),
-        (VIF(0b0011_1001), 1e-5),
-        (VIF(0b0011_1010), 1e-4),
-        (VIF(0b0011_1011), 1e-3),
-        (VIF(0b0011_1100), 1e-2),
-        (VIF(0b0011_1101), 1e-1),
-        (VIF(0b0011_1110), 1e0),
-        (VIF(0b0011_1111), 1e1),
-    ],
-)
-def test_volume_flow_meter_cubic_per_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeFlowMeterCubicPerHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0100_0000), 1e-7),
-        (VIF(0b0100_0001), 1e-6),
-        (VIF(0b0100_0010), 1e-5),
-        (VIF(0b0100_0011), 1e-4),
-        (VIF(0b0100_0100), 1e-3),
-        (VIF(0b0100_0101), 1e-2),
-        (VIF(0b0100_0110), 1e-1),
-        (VIF(0b0100_0111), 1e0),
-    ],
-)
-def test_volume_flow_meter_cubic_per_minute_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeFlowMeterCubicPerMinuteVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0100_1000), 1e-9),
-        (VIF(0b0100_1001), 1e-8),
-        (VIF(0b0100_1010), 1e-7),
-        (VIF(0b0100_1011), 1e-6),
-        (VIF(0b0100_1100), 1e-5),
-        (VIF(0b0100_1101), 1e-4),
-        (VIF(0b0100_1110), 1e-3),
-        (VIF(0b0100_1111), 1e-2),
-    ],
-)
-def test_volume_flow_meter_cubic_per_second_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, VolumeFlowMeterCubicPerSecondVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0101_0000), 1e-3),
-        (VIF(0b0101_0001), 1e-2),
-        (VIF(0b0101_0010), 1e-1),
-        (VIF(0b0101_0011), 1e0),
-        (VIF(0b0101_0100), 1e1),
-        (VIF(0b0101_0101), 1e2),
-        (VIF(0b0101_0110), 1e3),
-        (VIF(0b0101_0111), 1e4),
-    ],
-)
-def test_mass_flow_kilogram_per_hour_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, MassFlowKilogramPerHourVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0101_1000), 1e-3),
-        (VIF(0b0101_1001), 1e-2),
-        (VIF(0b0101_1010), 1e-1),
-        (VIF(0b0101_1011), 1e0),
-    ],
-)
-def test_temperature_flow_celsius_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureFlowCelsiusVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0101_1100), 1e-3),
-        (VIF(0b0101_1101), 1e-2),
-        (VIF(0b0101_1110), 1e-1),
-        (VIF(0b0101_1111), 1e0),
-    ],
-)
-def test_temperature_return_celsius_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureReturnCelsiusVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0110_0000), 1e-3),
-        (VIF(0b0110_0001), 1e-2),
-        (VIF(0b0110_0010), 1e-1),
-        (VIF(0b0110_0011), 1e-0),
-    ],
-)
-def test_temperature_difference_kelvin_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureDifferenceKelvinVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0110_0100), 1e-3),
-        (VIF(0b0110_0101), 1e-2),
-        (VIF(0b0110_0110), 1e-1),
-        (VIF(0b0110_0111), 1e-0),
-    ],
-)
-def test_temperature_external_celsius_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, TemperatureExternalCelsiusVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    ("vif", "coef"),
-    [
-        (VIF(0b0110_1000), 1e-3),
-        (VIF(0b0110_1001), 1e-2),
-        (VIF(0b0110_1010), 1e-1),
-        (VIF(0b0110_1011), 1e0),
-    ],
-)
-def test_pressure_bar_vif_codes(vif: VIF, coef: float):
-    _assert_vif_code(vif, PressureBarVIFCode, coef=coef)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0110_1100), VIF(0b0110_1101)],
-)
-def test_time_point_vif_codes(vif: VIF):
-    code = cast(
-        "TimePointVIFCode", _assert_vif_code(vif, TimePointVIFCode, coef=1)
-    )
-    match vif & 0x01:
-        case 0:
-            assert code.is_date()
-        case 1:
-            assert code.is_datetime()
-
-
-def test_hca_units_vif_code():
-    _assert_vif_code(VIF(0b0110_1110), HeatCostAllocatorUnitsVIFCode, coef=1)
-
-
-def test_reserved_e110_1111_vif_code():
-    _assert_vif_code(VIF(0b0110_1111), ReservedVIFCode, coef=1)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0111_0000), VIF(0b0111_0001), VIF(0b0111_0010), VIF(0b0111_0011)],
-)
-def test_averaging_duration_vif_codes(vif: VIF):
-    _assert_vif_code(vif, DurationAveragingVIFCode, coef=1)
-
-
-@pytest.mark.parametrize(
-    "vif",
-    [VIF(0b0111_0100), VIF(0b0111_0101), VIF(0b0111_0110), VIF(0b0111_0111)],
-)
-def test_actuality_duration_vif_codes(vif: VIF):
-    _assert_vif_code(vif, DurationActualityVIFCode, coef=1)
-
-
-def test_fabriaction_no_vif_code():
-    _assert_vif_code(VIF(0b0111_1000), FabricationNoVIFCode, coef=1)
-
-
-def test_enhanced_identification_vif_code():
-    _assert_vif_code(VIF(0b0111_1001), EnhancedIdentificationVIFCode, coef=1)
-
-
-def test_bus_address_vif_code():
-    _assert_vif_code(VIF(0b0111_1010), BusAddressVIFCode, coef=1)
-
-
-def test_special_purpose_vif_codes():
-    _assert_vif_code(VIF(0b0111_1100), UserDefinedVIFCode, coef=1)
-    _assert_vif_code(VIF(0b0111_1110), AnyVIFCode, coef=1)
-    _assert_vif_code(VIF(0b0111_1111), ManufacturerSpecificVIFCode, coef=1)


### PR DESCRIPTION
The idea of defining for each code or a group of related codes a dedicated class appeared to be discourageable because it leads to plethora of classes and increasing the level of teadiousness. The transition to dataclasses seems promising in terms of degrees of freedom.

Regardless the `_VIF_CODE_MAP` got bigger and stretched, only one VIFCode (data)class is left and is pretty generic. Also, the unit tests got simpler (in a way) and more uniform which is a good indirect sign.

Many thanks to this implementation in C: https://github.com/rscada/libmbus/blob/master/mbus/mbus-protocol-aux.c#L42 - a good example of KISS.