### PR TITLE
Improve bool, int and uint parsers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.5.1
+
+- update integer parsers: `parse_bool`, `parse_int` and `parse_uint` ([PR-24](https://github.com/stankudrow/pymbus/pull/24)):
+  - add the `byteorder` option to the given integer parsers
+  - these functions rely on the `int.from_bytes` method
+
 ## v0.5.0
 
 - update VIF codes: tables and utils ([PR-22](https://github.com/stankudrow/pymbus/pull/22)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymbus"
-version = "0.6.0"
+version = "0.5.1"
 description = "Python Meter-Bus codec."
 authors = [
     { name = "Stanley Kudrow", email = "stankudrow@reply.no" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymbus"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python Meter-Bus codec."
 authors = [
     { name = "Stanley Kudrow", email = "stankudrow@reply.no" }
@@ -174,3 +174,4 @@ fixable = ["I", "ICN", "ISC"]
     "PT011",  # https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
     "S",
 ]
+"tests/mbus_types/test_ints.py" = ["ERA001"]

--- a/src/pymbus/mbtypes.py
+++ b/src/pymbus/mbtypes.py
@@ -44,6 +44,7 @@ import struct
 from collections.abc import Iterable
 from contextlib import suppress
 from datetime import date, datetime, time, timezone, tzinfo
+from typing import Literal
 
 from pymbus.constants import BIG_ENDIAN, NIBBLE
 from pymbus.exceptions import MBusError, MBusLengthError
@@ -100,35 +101,24 @@ def parse_bcd_uint(ibytes: BytesType) -> int:
     return number
 
 
-def parse_int(ibytes: BytesType) -> int:
+def parse_int(
+    ibytes: BytesType, *, byteorder: Literal["big", "little"] = BIG_ENDIAN
+) -> int:
     """Returns the signed integer from a byte sequence.
 
     The "Binary Integer" type = "Type B".
-    The bytes are parsed along the Big endian order.
+    The bytes are parsed along the Big endian order by default.
 
+    Notes
+    -----
     The function is greedy.
-
-    Notes:
-    ------
-    An older implementation:
-    ```python
-    neg_sign = bytez[-1] & 0x80
-    value = 0
-    for byte in reversed(bytez):
-        value = value << BYTE
-        if neg_sign:
-            value += byte ^ 0xFF  # two's compliment
-        else:
-            value += byte
-    if neg_sign:
-        value = (-value) - 1  # two's compliment
-    return value
-    ```
 
     Parameters
     ----------
     ibytes: BytesType
         the sequence of bytes for "Type B" parsing
+    byteorder : Literal["big", "little"], default "big"
+        the byte order (endianness)
 
     Raises
     ------
@@ -141,21 +131,27 @@ def parse_int(ibytes: BytesType) -> int:
     """
     bytez = _validate_non_empty_bytes(ibytes)
 
-    return int.from_bytes(
-        bytes(reversed(bytez)), byteorder=BIG_ENDIAN, signed=True
-    )
+    return int.from_bytes(bytes(bytez), byteorder=byteorder, signed=True)
 
 
-def parse_uint(ibytes: BytesType) -> int:
+def parse_uint(
+    ibytes: BytesType, *, byteorder: Literal["big", "little"] = BIG_ENDIAN
+) -> int:
     """Returns the unsigned integer from a byte sequence.
 
     The "Unsigned Integer" type = "Type C".
-    The bytes are parsed along the Big endian order.
+    The bytes are parsed along the Big endian order by default.
+
+    Notes
+    -----
+    The function is greedy.
 
     Parameters
     ----------
     ibytes: BytesType
         the sequence of bytes for "Type C" parsing
+    byteorder : Literal["big", "little"], default "big"
+        the byte order (endianness)
 
     Raises
     ------
@@ -168,24 +164,26 @@ def parse_uint(ibytes: BytesType) -> int:
     """
     bytez = _validate_non_empty_bytes(ibytes)
 
-    return int.from_bytes(
-        bytes(reversed(bytez)), byteorder=BIG_ENDIAN, signed=False
-    )
+    return int.from_bytes(bytes(bytez), byteorder=byteorder, signed=False)
 
 
 ## boolean section
 
 
-def parse_bool(ibytes: BytesType) -> bool:
+def parse_bool(
+    ibytes: BytesType, *, byteorder: Literal["big", "little"] = BIG_ENDIAN
+) -> bool:
     """Returns the boolean from a byte sequence.
 
     The "Boolean" type = "Type D".
-    The bytes are parsed along the Big endian order.
+    The bytes are parsed along the Big endian order by default.
 
     Parameters
     ----------
     ibytes: BytesType
         the sequence of bytes for "Type D" parsing
+    byteorder : Literal["big", "little"], default "big"
+        the byte order (endianness)
 
     Raises
     ------
@@ -196,7 +194,7 @@ def parse_bool(ibytes: BytesType) -> bool:
     -------
     bool
     """
-    return bool(parse_uint(ibytes))
+    return bool(parse_uint(ibytes, byteorder=byteorder))
 
 
 ## floating point (real) numbers section

--- a/tests/mbus_types/test_bool.py
+++ b/tests/mbus_types/test_bool.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 
 import pytest
 
+from pymbus.constants import BIG_ENDIAN, LITTLE_ENDIAN
 from pymbus.mbtypes import parse_bool
 
 
@@ -16,4 +17,5 @@ from pymbus.mbtypes import parse_bool
     ],
 )
 def test_parse_boolean(it: Iterable, answer: int):
-    assert parse_bool(bytes(it)) == answer
+    for endianness in (BIG_ENDIAN, LITTLE_ENDIAN):
+        assert parse_bool(bytes(it), byteorder=endianness) == answer

--- a/tests/mbus_types/test_ints.py
+++ b/tests/mbus_types/test_ints.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from math import isclose
 from typing import Literal
 
 import pytest
@@ -119,3 +120,24 @@ def test_parse_uint_bytes(
 def test_parse_uint_empty():
     with pytest.raises(MBusError):
         parse_uint(bytes([]))
+
+
+@pytest.mark.parametrize(
+    ("data", "answer"),
+    [
+        (b"\x00\x00\x1f\x40", 8000),
+        (b"\x00\x00\x27\xb6", 10166),
+        (b"\x00\x00\x17\xf4", 6132),
+        (b"\x00\x00\x00\x2f", 47),
+        (b"\x00\x00\x0c\x72", 3186),
+        (b"\x07\x6d", 1901),
+        (b"\x07\x12", 1810),
+        (b"\x00\x00\x4a\x45", 19013),
+    ],
+)
+def test_positive_ints(data: bytes, answer: float):
+    int_res = parse_int(data)
+    uint_res = parse_uint(data)
+
+    assert isclose(int_res, answer)
+    assert isclose(uint_res, answer)

--- a/tests/mbus_types/test_ints.py
+++ b/tests/mbus_types/test_ints.py
@@ -12,114 +12,91 @@ from pymbus.mbtypes import (
 )
 
 
-@pytest.mark.parametrize("endianness", [BIG_ENDIAN, LITTLE_ENDIAN])
-@pytest.mark.parametrize(
-    ("it", "answer"),
-    [
-        ([0b0000_0000], 0),
-        ([0b1000_0000], -128),
-        ([0b1000_0001], -127),
-        ([0b0111_1111], 127),
-        ([0b1111_1111], -1),
-        # (
-        #     # <255, 1>
-        #
-        #     # non-negative -> 1 & 0x80 = 0 (False)
-        #     # 11) 0 << 8 = 0
-        #     # 12) 0 + 0000_0001 = 1
-        #     # 21) 1 <<< 8 = 1_0000_0000 = 256
-        #     # 22) 256 + 1111_1111 = 256 + 255 = 511
-        #     511,
-        # ),
-        # (
-        #     # <255, 129>
-        #     [0b1111_1111, 0b1000_0001],
-        #     # non-negative -> 129 & 0x80 = 1
-        #     # 11) 0 << 8 = 0
-        #     # 12) 0 + (129 ^ 0xFF) = 0 + 0111_1110 = 126
-        #     # 21) 128 << 8 = 0111_1110_0000_0000 = 32256
-        #     # 22) 32256 + (255 ^ 0xFF) = 32256
-        #     # neg -> True -> (-32256) - 1 = -32257
-        #     -32257,
-        # ),
-    ],
-)
-def test_parse_int_byte(
-    it: Iterable, endianness: Literal["big", "little"], answer: int
-):
-    assert parse_int(bytes(it), byteorder=endianness) == answer
+class TestParseInt:
+    @pytest.mark.parametrize("endianness", [BIG_ENDIAN, LITTLE_ENDIAN])
+    @pytest.mark.parametrize(
+        ("it", "answer"),
+        [
+            ([0b0000_0000], 0),
+            ([0b1000_0000], -128),
+            ([0b1000_0001], -127),
+            ([0b0111_1111], 127),
+            ([0b1111_1111], -1),
+        ],
+    )
+    def test_parse_int_byte(
+        self, it: Iterable, endianness: Literal["big", "little"], answer: int
+    ):
+        assert parse_int(bytes(it), byteorder=endianness) == answer
+
+    @pytest.mark.parametrize(
+        ("it", "endianness", "answer"),
+        [
+            (
+                [0b1111_1111, 0b0000_0001],
+                # [0xFF, 0x01]
+                # 0xFF => minus (MSB is 1) -> work with 0x7F = 127
+                # ~0xFF = 0b0000_0000 -> 0x00 = 0
+                # ~0x01 = 0b1111_1110 -> 0xFE = 254
+                # Total: -((254 + 0) + 1) = -255
+                BIG_ENDIAN,
+                -255,
+            ),
+            (
+                [0b1111_1111, 0b0000_0001],
+                LITTLE_ENDIAN,
+                511,  # [0x01, 0xFF] = 256 + 255 = 511
+            ),
+        ],
+    )
+    def test_parse_int_bytes(
+        self, it: Iterable, endianness: Literal["big", "little"], answer: int
+    ):
+        assert parse_int(bytes(it), byteorder=endianness) == answer
+
+    def test_parse_int_empty(self):
+        with pytest.raises(MBusError):
+            parse_int(bytes([]))
 
 
-@pytest.mark.parametrize(
-    ("it", "endianness", "answer"),
-    [
-        (
-            [0b1111_1111, 0b0000_0001],
-            # [0xFF, 0x01]
-            # 0xFF => minus (MSB is 1) -> work with 0x7F = 127
-            # ~0xFF = 0b0000_0000 -> 0x00 = 0
-            # ~0x01 = 0b1111_1110 -> 0xFE = 254
-            # Total: -((254 + 0) + 1) = -255
-            BIG_ENDIAN,
-            -255,
-        ),
-        (
-            [0b1111_1111, 0b0000_0001],
-            LITTLE_ENDIAN,
-            511,  # [0x01, 0xFF] = 256 + 255 = 511
-        ),
-    ],
-)
-def test_parse_int_bytes(
-    it: Iterable, endianness: Literal["big", "little"], answer: int
-):
-    assert parse_int(bytes(it), byteorder=endianness) == answer
+class TestParseUint:
+    @pytest.mark.parametrize("endianness", [BIG_ENDIAN, LITTLE_ENDIAN])
+    @pytest.mark.parametrize(
+        ("it", "answer"),
+        [
+            ([0b0000_0000], 0),
+            ([0b1000_0000], 128),
+            ([0b1111_1111], 255),
+        ],
+    )
+    def test_parse_uint_byte(
+        self, it: Iterable, endianness: Literal["big", "little"], answer: int
+    ):
+        assert parse_uint(bytes(it), byteorder=endianness) == answer
 
+    @pytest.mark.parametrize(
+        ("it", "endianness", "answer"),
+        [
+            (
+                [0b1111_1111, 0b0000_0001],
+                BIG_ENDIAN,
+                65281,
+            ),
+            (
+                [0b1111_1111, 0b0000_0001],
+                LITTLE_ENDIAN,
+                511,
+            ),
+        ],
+    )
+    def test_parse_uint_bytes(
+        self, it: Iterable, endianness: Literal["big", "little"], answer: int
+    ):
+        assert parse_uint(bytes(it), byteorder=endianness) == answer
 
-def test_parse_int_empty():
-    with pytest.raises(MBusError):
-        parse_int(bytes([]))
-
-
-@pytest.mark.parametrize("endianness", [BIG_ENDIAN, LITTLE_ENDIAN])
-@pytest.mark.parametrize(
-    ("it", "answer"),
-    [
-        ([0b0000_0000], 0),
-        ([0b1000_0000], 128),
-        ([0b1111_1111], 255),
-    ],
-)
-def test_parse_uint_byte(
-    it: Iterable, endianness: Literal["big", "little"], answer: int
-):
-    assert parse_uint(bytes(it), byteorder=endianness) == answer
-
-
-@pytest.mark.parametrize(
-    ("it", "endianness", "answer"),
-    [
-        (
-            [0b1111_1111, 0b0000_0001],
-            BIG_ENDIAN,
-            65281,
-        ),
-        (
-            [0b1111_1111, 0b0000_0001],
-            LITTLE_ENDIAN,
-            511,
-        ),
-    ],
-)
-def test_parse_uint_bytes(
-    it: Iterable, endianness: Literal["big", "little"], answer: int
-):
-    assert parse_uint(bytes(it), byteorder=endianness) == answer
-
-
-def test_parse_uint_empty():
-    with pytest.raises(MBusError):
-        parse_uint(bytes([]))
+    def test_parse_uint_empty(self):
+        with pytest.raises(MBusError):
+            parse_uint(bytes([]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
These parsers (parse_(bool|int|uint)) now rely on `int.from_bytes` method which is a good idea. The `byteorder` option gives some freedom and puts aside the need to reverse bytes if necessary.

The changes are not breaking, that is why the version ought to be v0.5.1!